### PR TITLE
Sort results of "ls", "color", and "commands"

### DIFF
--- a/Containers/ScrollableContainer.cs
+++ b/Containers/ScrollableContainer.cs
@@ -127,7 +127,7 @@ namespace Terminal.Containers
                 AutowrapMode = TextServer.AutowrapMode.WordSmart
             };
 
-            List<string> entityList = entities.Select(entity =>
+            List<string> entityList = entities.OrderBy(entity => $"{entity}").Select(entity =>
             {
                 if (entity.Permissions.Contains(Permission.UserExecutable) || entity.Permissions.Contains(Permission.AdminExecutable))
                 {
@@ -148,7 +148,8 @@ namespace Terminal.Containers
         {
             if (!_configService.Colors.TryGetValue(colorName, out Color newColor))
             {
-                CreateResponse($"Invalid color option. Possible color options are: {string.Join(", ", _configService.Colors.Keys)}.");
+                var sortedColors = string.Join(", ", _configService.Colors.Keys.OrderBy(key => key).Select(key => key));
+                CreateResponse($"Invalid color option. Possible color options are: {sortedColors}.");
                 return;
             }
 

--- a/Services/AutoCompleteService.cs
+++ b/Services/AutoCompleteService.cs
@@ -27,11 +27,6 @@ namespace Terminal.Services
         /// </summary>
         public event Action<string> OnAutocomplete;
 
-        /// <summary>
-        /// Invoked to stop input bubbling.
-        /// </summary>
-        public event Action OnStopInputBubble;
-
         private static readonly List<UserCommand> _validAutoCompleteCommands = new()
         {
             UserCommand.ChangeDirectory,

--- a/Services/ConfigService.cs
+++ b/Services/ConfigService.cs
@@ -95,7 +95,8 @@ namespace Terminal.Services
             }
 
             var colorsContentsMinusReplacement = colorsExecutableFile.Contents.Split("[COLORS:").First();
-            colorsExecutableFile.Contents = string.Concat('\n', colorsContentsMinusReplacement, '\n', "[COLORS:", string.Join(", ", newColors.Keys), "]");
+            var sortedColors = string.Join(", ", newColors.Keys.OrderBy(key => key).Select(key => key));
+            colorsExecutableFile.Contents = string.Concat('\n', colorsContentsMinusReplacement, '\n', "[COLORS:", sortedColors, "]");
         }
     }
 }

--- a/Services/UserCommandService.cs
+++ b/Services/UserCommandService.cs
@@ -196,7 +196,8 @@ namespace Terminal.Services
             }
 
             var commandsContentsMinusReplacement = commandsExecutableFile.Contents.Split("[COMMANDS:").First();
-            commandsExecutableFile.Contents = string.Concat('\n', commandsContentsMinusReplacement, '\n', "[COMMANDS:", string.Join(", ", newCommandNames), "]");
+            var sortedCommands = string.Join(", ", newCommandNames.OrderBy(command => command).Select(command => command));
+            commandsExecutableFile.Contents = string.Concat('\n', commandsContentsMinusReplacement, '\n', "[COMMANDS:", sortedCommands, "]");
         }
 
         private static string GetOutputFromTokens(Dictionary<string, string> outputTokens)


### PR DESCRIPTION
This is for Issue #35. 

It will also alphabetically sort the output of `help color`, `color`, and `commands`.