### PR TITLE
Add ability for flags/switches/arguments to "network"

### DIFF
--- a/Constants/DirectoryConstants.cs
+++ b/Constants/DirectoryConstants.cs
@@ -8,6 +8,16 @@ namespace Terminal.Constants
 {
     public static class DirectoryConstants
     {
+        /// <summary>
+        /// The separator character for lines of help information, written into the executable files.
+        /// </summary>
+        public const string HelpLineSeparator = "\n---\n";
+
+        /// <summary>
+        /// The separator character for keys and values of help information, written into the executable files.
+        /// </summary>
+        public const string HelpKeyValueSeparator = ":=:";
+
         private static readonly List<Permission> _adminReadWritePermissions = new() { Permission.AdminRead, Permission.AdminWrite };
         private static readonly List<Permission> _userReadWritePermissions = new() { Permission.AdminRead, Permission.AdminWrite, Permission.UserRead, Permission.UserWrite };
         private static readonly List<Permission> _userReadPermissions = new() { Permission.AdminRead, Permission.AdminWrite, Permission.UserRead };
@@ -116,8 +126,10 @@ namespace Terminal.Constants
             },
             ["network"] = new()
             {
-                ["COMMAND"] = "network [net]",
-                ["REMARKS"] = "View current networking information."
+                ["COMMAND"] = "net [network]",
+                ["REMARKS"] = "View current networking information.",
+                ["ARGUMENTS"] = "-a [--active]: Show active networks.\n-d [--device]: Show network devices.\n-n [--name]: Show network names.\n-v6 [--ipv6]: Show ipv6 addresses.\n-v8 [--ipv8]: Show ipv8 addresses.",
+                ["EXAMPLES"] = "net -a -v8    : Show the ipv8 addresses for active networks."
             }
         };
 
@@ -178,7 +190,7 @@ namespace Terminal.Constants
             systemProgramsDirectory.Entities = AllDefaultCommands.Select(command => new DirectoryEntity()
             {
                 Name = command.Key,
-                Contents = string.Join("\n", command.Value.Select(commandInfo => $"[{commandInfo.Key}:{commandInfo.Value}]")),
+                Contents = string.Join(HelpLineSeparator, command.Value.Select(commandInfo => $"[{commandInfo.Key}{HelpKeyValueSeparator}{commandInfo.Value}]")),
                 ParentId = systemProgramsDirectory.Id,
                 Permissions = _userExecutablePermissions
             }).ToList();

--- a/Constants/ServicePathConstants.cs
+++ b/Constants/ServicePathConstants.cs
@@ -37,5 +37,10 @@ namespace Terminal.Constants
         /// The <see cref="AutoCompleteService"/> single path in Godot.
         /// </summary>
         public const string AutoCompleteServicePath = "/root/AutoCompleteService";
+
+        /// <summary>
+        /// The <see cref="NetworkService"/> single path in Godot.
+        /// </summary>
+        public const string NetworkServicePath = "/root/NetworkService";
     }
 }

--- a/Inputs/UserInput.cs
+++ b/Inputs/UserInput.cs
@@ -70,6 +70,7 @@ namespace Terminal.Inputs
         private UserCommandService _userCommandService;
         private DirectoryService _directoryService;
         private AutoCompleteService _autoCompleteService;
+        private NetworkService _networkService;
         private bool _hasFocus = false;
         private int _commandMemoryIndex;
 
@@ -79,10 +80,13 @@ namespace Terminal.Inputs
             _directoryService = GetNode<DirectoryService>(ServicePathConstants.DirectoryServicePath);
             _persistService = GetNode<PersistService>(ServicePathConstants.PersistServicePath);
             _autoCompleteService = GetNode<AutoCompleteService>(ServicePathConstants.AutoCompleteServicePath);
-            _autoCompleteService.OnInvalidAutocomplete += ListDirectoryAndCreateNewInput;
-            _autoCompleteService.OnAutocomplete += FillInputWithAutocompletedPhrase;
+            _networkService = GetNode<NetworkService>(ServicePathConstants.NetworkServicePath);
             _keyboardSounds = GetTree().Root.GetNode<KeyboardSounds>(KeyboardSounds.AbsolutePath);
             _commandMemoryIndex = _persistService.CommandMemory.Count;
+
+            _autoCompleteService.OnInvalidAutocomplete += ListDirectoryAndCreateNewInput;
+            _autoCompleteService.OnAutocomplete += FillInputWithAutocompletedPhrase;
+            _networkService.OnShowNetwork += ShowNetworkResponse;
 
             Text = _userCommandService.GetCommandPrompt();
             SetCaretColumn(Text.Length);
@@ -128,6 +132,7 @@ namespace Terminal.Inputs
             // unsubscribe from the auto-complete events to prevent old inputs from getting autocompleted.
             _autoCompleteService.OnInvalidAutocomplete -= ListDirectoryAndCreateNewInput;
             _autoCompleteService.OnAutocomplete -= FillInputWithAutocompletedPhrase;
+            _networkService.OnShowNetwork -= ShowNetworkResponse;
         }
 
         private Action RouteCommand(string command)
@@ -150,7 +155,7 @@ namespace Terminal.Inputs
                 UserCommand.Date => () => CreateSimpleTerminalResponse(DateTime.UtcNow.AddYears(250).ToLongDateString()),
                 UserCommand.Time => () => CreateSimpleTerminalResponse(DateTime.UtcNow.AddYears(250).ToLongTimeString()),
                 UserCommand.Now => () => CreateSimpleTerminalResponse(string.Join(", ", DateTime.UtcNow.AddYears(250).ToLongTimeString(), DateTime.UtcNow.AddYears(250).ToLongDateString())),
-                UserCommand.Network => () => Network(),
+                UserCommand.Network => () => _networkService.ShowNetworkInformation(parsedTokens),
                 UserCommand.Color => () => ChangeColor(parsedTokens.Take(2).Last()),
                 UserCommand.Save => () => SaveProgress(),
                 UserCommand.Exit => () => Exit(),
@@ -277,7 +282,7 @@ namespace Terminal.Inputs
 
         private void ChangePermissions(string entityName, string newPermissionsSet) => EmitSignal(SignalName.ChangePermissionsCommand, entityName, newPermissionsSet);
 
-        private void Network() => EmitSignal(SignalName.NetworkCommand);
+        private void ShowNetworkResponse(string networkResponse) => EmitSignal(SignalName.KnownCommand, networkResponse);
 
         private void ListDirectoryAndCreateNewInput()
         {

--- a/Inputs/UserInput.cs
+++ b/Inputs/UserInput.cs
@@ -155,7 +155,7 @@ namespace Terminal.Inputs
                 UserCommand.Date => () => CreateSimpleTerminalResponse(DateTime.UtcNow.AddYears(250).ToLongDateString()),
                 UserCommand.Time => () => CreateSimpleTerminalResponse(DateTime.UtcNow.AddYears(250).ToLongTimeString()),
                 UserCommand.Now => () => CreateSimpleTerminalResponse(string.Join(", ", DateTime.UtcNow.AddYears(250).ToLongTimeString(), DateTime.UtcNow.AddYears(250).ToLongDateString())),
-                UserCommand.Network => () => _networkService.ShowNetworkInformation(parsedTokens),
+                UserCommand.Network => () => _networkService.ShowNetworkInformation(parsedTokens.Skip(1)),
                 UserCommand.Color => () => ChangeColor(parsedTokens.Take(2).Last()),
                 UserCommand.Save => () => SaveProgress(),
                 UserCommand.Exit => () => Exit(),

--- a/Models/NetworkResponse.cs
+++ b/Models/NetworkResponse.cs
@@ -1,0 +1,60 @@
+﻿namespace Terminal.Models
+{
+    /// <summary>
+    /// Represents a response containing network information.
+    /// </summary>
+    public readonly struct NetworkResponse
+    {
+        /// <summary>
+        /// Creates a new fully-qualified <see cref="NetworkResponse"/>.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the network to show.
+        /// </param>
+        /// <param name="device">
+        /// The network device to show.
+        /// </param>
+        /// <param name="ipv6">
+        /// The ipv6 address of the network to show.
+        /// </param>
+        /// <param name="ipv8">
+        /// The ipv8 address of the network to show.
+        /// </param>
+        /// <param name="isActive">
+        /// A flag indicating if the shown network is active.
+        /// </param>
+        public NetworkResponse(string name, string device, string ipv6, string ipv8, bool isActive = false)
+        {
+            Name = name;
+            Device = device;
+            Ipv6Address = ipv6;
+            Ipv8Address = ipv8;
+            IsActive = isActive;
+        }
+
+        /// <summary>
+        /// The name of the network.
+        /// </summary>
+        public readonly string Name { get; }
+
+        /// <summary>
+        /// The networking device.
+        /// </summary>
+        public readonly string Device { get; }
+
+        /// <summary>
+        /// The ipv6 address of the network.
+        /// </summary>
+        public readonly string Ipv6Address { get; }
+
+        /// <summary>
+        /// The ipv8 address of the network.
+        /// </summary>
+        public readonly string Ipv8Address { get; }
+
+        /// <summary>
+        /// A flag indicating if the network is active.
+        /// </summary>
+        public readonly bool IsActive { get; }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,11 +15,14 @@ terminal_os is a terminal game written in the Godot engine using .NET 8 and C#.
 - Make a directory in the current directory using the `makedirectory` command
 - List the hardware using the `listhardware` command
 - View the permissions of a file or directory using the `viewpermissions` command
+    - Use the `help viewpermissions` command to get information about permission bits
 - Change the permissions of a file or directory using the `changepermissions` command
+    - Use the `help changepermissions` command to get information about permission bits
 - Get the current date and time using the `now` command
     - Get the current date using the `date` command
     - Get the current time using the `time` command
 - Get the current networking information using the `network` command
+    - Use the `help network` command to get information about valid arguments
 - Add new colors to the terminal by using `edit` on the `/system/config/color.conf` file, and adding a name and hex value
 - Save your game by using the `save` command
 - Exit the terminal using the `exit` command (but not before using `save` to save your game)

--- a/Services/ConfigService.cs
+++ b/Services/ConfigService.cs
@@ -94,9 +94,9 @@ namespace Terminal.Services
                 return;
             }
 
-            var colorsContentsMinusReplacement = colorsExecutableFile.Contents.Split("[COLORS:").First();
+            var colorsContentsMinusReplacement = colorsExecutableFile.Contents.Split($"[COLORS{DirectoryConstants.HelpKeyValueSeparator}").First();
             var sortedColors = string.Join(", ", newColors.Keys.OrderBy(key => key).Select(key => key));
-            colorsExecutableFile.Contents = string.Concat('\n', colorsContentsMinusReplacement, '\n', "[COLORS:", sortedColors, "]");
+            colorsExecutableFile.Contents = string.Concat(colorsContentsMinusReplacement, DirectoryConstants.HelpLineSeparator, "[COLORS", DirectoryConstants.HelpKeyValueSeparator, sortedColors, "]");
         }
     }
 }

--- a/Services/NetworkService.cs
+++ b/Services/NetworkService.cs
@@ -5,6 +5,7 @@ using Godot;
 
 using Terminal.Constants;
 using Terminal.Extensions;
+using Terminal.Models;
 
 namespace Terminal.Services
 {
@@ -18,11 +19,39 @@ namespace Terminal.Services
         /// </summary>
         public event Action<string> OnShowNetwork;
 
+        private static readonly Dictionary<string, List<string>> _networkCommandFlags = new()
+        {
+            ["active"] = new() { "-a", "--active" },
+            ["name"] = new() { "-n", "--name" },
+            ["device"] = new() { "-d", "--device" },
+            ["ipv6"] = new() { "-v6", "--ipv6" },
+            ["ipv8"] = new() { "-v8", "--ipv8" },
+        };
+        private const int nameColumnLength = -10;
+        private const int deviceColumnLength = -8;
+        private const int ipv6ColumnLength = -22;
+        private const int ipv8ColumnLength = -18;
+
         private DirectoryService _directoryService;
 
         public override void _Ready()
         {
             _directoryService = GetNode<DirectoryService>(ServicePathConstants.DirectoryServicePath);
+        }
+
+        private Dictionary<string, List<string>> NetworkDevices
+        {
+            get
+            {
+                var networkDirectory = _directoryService.GetRootDirectory().FindDirectory("system").FindDirectory("network");
+                var networkResponse = networkDirectory.Entities.Where(entity => !entity.IsDirectory).Select(entity =>
+                {
+                    var networkEntityList = entity.Contents.Split('\n');
+                    return new KeyValuePair<string, List<string>>(entity.Name, networkEntityList.ToList());
+                }).ToList();
+
+                return new Dictionary<string, List<string>>(networkResponse);
+            }
         }
 
         /// <summary>
@@ -31,30 +60,81 @@ namespace Terminal.Services
         /// <param name="arguments">
         /// The command line arguments.
         /// </param>
-        public void ShowNetworkInformation(List<string> arguments)
+        public void ShowNetworkInformation(IEnumerable<string> arguments)
         {
-            var networkDirectory = _directoryService.GetRootDirectory().FindDirectory("system").FindDirectory("network");
-            var networkResponse = networkDirectory.Entities.Where(entity => !entity.IsDirectory).Select(entity =>
+            var showActive = arguments.Contains("-a");
+            var showName = arguments.Contains("-n") || !arguments.Any() || showActive;
+            var showDevice = arguments.Contains("-d") || !arguments.Any() || showActive;
+            var showIpv6 = arguments.Contains("-ipv6") || arguments.Contains("-v6") || !arguments.Any();
+            var showIpv8 = arguments.Contains("-ipv8") || arguments.Contains("-v8");
+
+            // if there was an unexpected argument, tell the user
+            List<string> unrecognizedArgs = new();
+            foreach(var argument in arguments)
             {
-                var networkEntityList = entity.Contents.Split('\n');
-                return new KeyValuePair<string, List<string>>(entity.Name, networkEntityList.ToList());
+                if(_networkCommandFlags.Values.All(flag => !flag.Contains(argument)))
+                {
+                    unrecognizedArgs.Add(argument);
+                }
+            }
+
+            if(unrecognizedArgs.Any())
+            {
+                OnShowNetwork?.Invoke($"\"{unrecognizedArgs.First()}\" is an invalid argument for the \"network\" command. Use \"help network\" to see valid arguments.");
+                return;
+            }
+
+            List<NetworkResponse> networkResponses = NetworkDevices.Select(networkDevice =>
+            {
+                var name = $"{networkDevice.Key}";
+                var device = $"{networkDevice.Value.First(value => value.Contains("device:")).Replace("device:", string.Empty).Trim()}";
+                var ipv6 = $"{networkDevice.Value.First(value => value.Contains("ipv6:")).Replace("ipv6:", string.Empty).Trim()}";
+                var ipv8 = $"{networkDevice.Value.First(value => value.Contains("ipv8:")).Replace("ipv8:", string.Empty).Trim()}";
+                var activeValue = $"{networkDevice.Value.First(value => value.Contains("active:")).Replace("active:", string.Empty).Trim()}";
+                var active = activeValue?.Equals("true", StringComparison.OrdinalIgnoreCase) ?? false;
+                return new NetworkResponse(name, device, ipv6, ipv8, active);
             }).ToList();
 
-            List<Tuple<string, string, string, string>> networkColumnsOutput = new()
+            List<string> columnTitles = new()
             {
-                new("Name", "Device", "Address (ipv6)", "Address (ipv8)"),
-                new("----", "------", "--------------", "--------------")
+                showName ? $"{"Name", nameColumnLength}" : string.Empty,
+                showDevice ? $"{"Device", deviceColumnLength}" : string.Empty,
+                showIpv6 ? $"{"Address (ipv6)", ipv6ColumnLength}" : string.Empty,
+                showIpv8 ? $"{"Address (ipv8)", ipv8ColumnLength}" : string.Empty,
+                showActive ? "Active" : string.Empty,
             };
-            networkColumnsOutput.AddRange(networkResponse.Select(nri =>
+            List<string> columnRowSeperators = new()
             {
-                var name = $"{nri.Key}";
-                var device = $"{nri.Value.First(value => value.Contains("device:")).Replace("device:", string.Empty).Trim()}";
-                var ipv6 = $"{nri.Value.First(value => value.Contains("ipv6:")).Replace("ipv6:", string.Empty).Trim()}";
-                var ipv8 = $"{nri.Value.First(value => value.Contains("ipv8:")).Replace("ipv8:", string.Empty).Trim()}";
-                return new Tuple<string, string, string, string>(name, device, ipv6, ipv8);
-            }).ToList());
+                showName ? new string('-', nameColumnLength * -1) : string.Empty,
+                showDevice ? new string('-', deviceColumnLength * -1) : string.Empty,
+                showIpv6 ? new string('-', ipv6ColumnLength * -1) : string.Empty,
+                showIpv8 ? new string('-', ipv8ColumnLength * -1) : string.Empty,
+                showActive ? new string('-', 6) : string.Empty,
+            };
 
-            OnShowNetwork?.Invoke(string.Join("\n", networkColumnsOutput.Select(networkOutput => $"{networkOutput.Item1,-10}{networkOutput.Item2,-10}{networkOutput.Item3,-24}{networkOutput.Item4}")));
+            List<string> output = new()
+            {
+                string.Join("---", columnRowSeperators.Where(columnRow => !string.IsNullOrEmpty(columnRow))),
+                string.Join(" | ", columnTitles.Where(columnTitle => !string.IsNullOrEmpty(columnTitle))),
+                string.Join("-|-", columnRowSeperators.Where(columnRow => !string.IsNullOrEmpty(columnRow)))
+            };
+
+            foreach(var networkResponse in networkResponses)
+            {
+                List<string> dataRow = new()
+                {
+                    showName ? $"{networkResponse.Name, nameColumnLength}" : string.Empty,
+                    showDevice ? $"{networkResponse.Device, deviceColumnLength}" : string.Empty,
+                    showIpv6 ? $"{networkResponse.Ipv6Address, ipv6ColumnLength}" : string.Empty,
+                    showIpv8 ? $"{networkResponse.Ipv8Address, ipv8ColumnLength}" : string.Empty,
+                    showActive ? $"{networkResponse.IsActive}".ToLowerInvariant() : string.Empty,
+                };
+
+                output.Add(string.Join(" | ", dataRow.Where(row => !string.IsNullOrEmpty(row))));
+            }
+            output.Add(string.Join("---", columnRowSeperators.Where(columnRow => !string.IsNullOrEmpty(columnRow))));
+
+            OnShowNetwork?.Invoke(string.Join("\n", output));
         }
     }
 }

--- a/Services/NetworkService.cs
+++ b/Services/NetworkService.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Godot;
+
+using Terminal.Constants;
+using Terminal.Extensions;
+
+namespace Terminal.Services
+{
+    public partial class NetworkService : Node
+    {
+        /// <summary>
+        /// Invoked when showing networking information.
+        /// <para>
+        /// Will continue to run unless unsubscribed after running the method.
+        /// </para>
+        /// </summary>
+        public event Action<string> OnShowNetwork;
+
+        private DirectoryService _directoryService;
+
+        public override void _Ready()
+        {
+            _directoryService = GetNode<DirectoryService>(ServicePathConstants.DirectoryServicePath);
+        }
+
+        /// <summary>
+        /// Shows networking information by reading the /system/network directory and files.
+        /// </summary>
+        /// <param name="arguments">
+        /// The command line arguments.
+        /// </param>
+        public void ShowNetworkInformation(List<string> arguments)
+        {
+            var networkDirectory = _directoryService.GetRootDirectory().FindDirectory("system").FindDirectory("network");
+            var networkResponse = networkDirectory.Entities.Where(entity => !entity.IsDirectory).Select(entity =>
+            {
+                var networkEntityList = entity.Contents.Split('\n');
+                return new KeyValuePair<string, List<string>>(entity.Name, networkEntityList.ToList());
+            }).ToList();
+
+            List<Tuple<string, string, string, string>> networkColumnsOutput = new()
+            {
+                new("Name", "Device", "Address (ipv6)", "Address (ipv8)"),
+                new("----", "------", "--------------", "--------------")
+            };
+            networkColumnsOutput.AddRange(networkResponse.Select(nri =>
+            {
+                var name = $"{nri.Key}";
+                var device = $"{nri.Value.First(value => value.Contains("device:")).Replace("device:", string.Empty).Trim()}";
+                var ipv6 = $"{nri.Value.First(value => value.Contains("ipv6:")).Replace("ipv6:", string.Empty).Trim()}";
+                var ipv8 = $"{nri.Value.First(value => value.Contains("ipv8:")).Replace("ipv8:", string.Empty).Trim()}";
+                return new Tuple<string, string, string, string>(name, device, ipv6, ipv8);
+            }).ToList());
+
+            OnShowNetwork?.Invoke(string.Join("\n", networkColumnsOutput.Select(networkOutput => $"{networkOutput.Item1,-10}{networkOutput.Item2,-10}{networkOutput.Item3,-24}{networkOutput.Item4}")));
+        }
+    }
+}

--- a/Services/UserCommandService.cs
+++ b/Services/UserCommandService.cs
@@ -111,17 +111,17 @@ namespace Terminal.Services
             {
                 var parsedCommandFiles = AllCommandFiles.Select(command =>
                 {
-                    var helpLines = command.Contents.Split('\n');
-                    var parsedHelpLines = helpLines.Select(line => line.TrimStart('[').TrimEnd(']'));
+                    var helpLines = command.Contents.Split(DirectoryConstants.HelpLineSeparator, StringSplitOptions.RemoveEmptyEntries);
+                    var parsedHelpLines = helpLines.Select(line => line.Remove(line.Length - 1).Remove(0, 1));
                     var separatedLines = parsedHelpLines.Select(line =>
                     {
-                        var keyValuePair = line.Split(':', StringSplitOptions.RemoveEmptyEntries);
+                        var keyValuePair = line.Split(DirectoryConstants.HelpKeyValueSeparator, StringSplitOptions.RemoveEmptyEntries);
                         if (keyValuePair.Length != 2)
                         {
                             return default;
                         }
 
-                        return new KeyValuePair<string, string>(line.Split(':').First(), line.Split(':').Last());
+                        return new KeyValuePair<string, string>(keyValuePair.First(), string.Concat(keyValuePair.Skip(1)));
                     }).Where(line => line.Key != default && line.Value != default);
 
                     return new KeyValuePair<string, Dictionary<string, string>>(command.Name, new Dictionary<string, string>(separatedLines));
@@ -195,9 +195,9 @@ namespace Terminal.Services
                 return;
             }
 
-            var commandsContentsMinusReplacement = commandsExecutableFile.Contents.Split("[COMMANDS:").First();
+            var commandsContentsMinusReplacement = commandsExecutableFile.Contents.Split($"[COMMANDS{DirectoryConstants.HelpKeyValueSeparator}").First();
             var sortedCommands = string.Join(", ", newCommandNames.OrderBy(command => command).Select(command => command));
-            commandsExecutableFile.Contents = string.Concat('\n', commandsContentsMinusReplacement, '\n', "[COMMANDS:", sortedCommands, "]");
+            commandsExecutableFile.Contents = string.Concat(commandsContentsMinusReplacement, DirectoryConstants.HelpLineSeparator, "[COMMANDS", DirectoryConstants.HelpKeyValueSeparator, sortedCommands, "]");
         }
 
         private static string GetOutputFromTokens(Dictionary<string, string> outputTokens)

--- a/project.godot
+++ b/project.godot
@@ -25,6 +25,7 @@ ConfigService="*res://Services/ConfigService.cs"
 PersistService="*res://Services/PersistService.cs"
 ScreenNavigator="*res://Navigators/ScreenNavigator.cs"
 AutoCompleteService="*res://Services/AutoCompleteService.cs"
+NetworkService="*res://Services/NetworkService.cs"
 
 [display]
 


### PR DESCRIPTION
This PR will introduce arguments for the `network` command:
- `-a`, `--active` to show active networks
- `-n`, `--name` to show network names
- `-d`, `--device` to show network devices
- `-v6`, `--ipv6` to show ipv6 addresses
- `-v8`, `--ipv8` to show ipv8 addresses

It also safeguards against invalid arguments, and lets the user know if they provide one, and gives them a clue to use the `help network` command to get more information about flags.

This PR will also fix executable file saving and parsing, so the `help` command shows all the data properly. The issue was that there was a split on `\n` for lines, but values in the help text could contain `\n`. Similarly, separating keys and values for help was using `:`, but `:` could be included in the help values. Those separator characters have been updated to more specific strings that will not show up in help information.