### PR TITLE
Fix relative autocomplete, add "ls" context

### DIFF
--- a/Constants/DirectoryConstants.cs
+++ b/Constants/DirectoryConstants.cs
@@ -56,7 +56,8 @@ namespace Terminal.Constants
             ["list"] = new()
             {
                 ["COMMAND"] = "ls [list]",
-                ["REMARKS"] = "Lists contents of a directory."
+                ["REMARKS"] = "Lists contents of a directory.",
+                ["EXAMPLES"] = "ls        : List the contents of the current directory.\nls /system : List the contents of the \"/system\" directory."
             },
             ["change"] = new()
             {

--- a/Containers/ScrollableContainer.cs
+++ b/Containers/ScrollableContainer.cs
@@ -173,7 +173,29 @@ namespace Terminal.Containers
             CreateResponse("Progress saved.");
         }
 
-        private void ListDirectoryCommandResponse() => CreateListDirectoryResponse(_directoryService.GetCurrentDirectory().Entities);
+        private void ListDirectoryCommandResponse(string directoryToList)
+        {
+            if(string.IsNullOrEmpty(directoryToList))
+            {
+                CreateListDirectoryResponse(_directoryService.GetCurrentDirectory().Entities);
+                return;
+            }
+
+            if(directoryToList.Equals(TerminalCharactersConstants.Separator.ToString()))
+            {
+                CreateListDirectoryResponse(_directoryService.GetRootDirectory().Entities);
+                return;
+            }
+
+            var absoluteDirectoryToList = _directoryService.GetRootDirectory().FindDirectory(directoryToList.TrimEnd('/'));
+            if(absoluteDirectoryToList == null)
+            {
+                CreateResponse($"The directory {directoryToList} does not exist.");
+                return;
+            }
+
+            CreateListDirectoryResponse(absoluteDirectoryToList.Entities);
+        }
 
         private void MakeFileCommandResponse(string fileName)
         {

--- a/Services/AutoCompleteService.cs
+++ b/Services/AutoCompleteService.cs
@@ -20,7 +20,7 @@ namespace Terminal.Services
         /// Will continue to run unless unsubscribed after running the method.
         /// </para>
         /// </summary>
-        public event Action OnInvalidAutocomplete;
+        public event Action<string> OnInvalidAutocomplete;
 
         /// <summary>
         /// Invoked when an auto-completed phrase is generated successfully.
@@ -36,7 +36,8 @@ namespace Terminal.Services
             UserCommand.ViewFile,
             UserCommand.EditFile,
             UserCommand.ViewPermissions,
-            UserCommand.ChangePermissions
+            UserCommand.ChangePermissions,
+            UserCommand.ListDirectory
         };
 
         private DirectoryService _directoryService;
@@ -44,7 +45,6 @@ namespace Terminal.Services
         private DirectoryEntity _autocompletedEntity;
         private string _partialPath;
 
-        // Called when the node enters the scene tree for the first time.
         public override void _Ready()
         {
             _directoryService = GetNode<DirectoryService>(ServicePathConstants.DirectoryServicePath);
@@ -59,34 +59,66 @@ namespace Terminal.Services
         /// </param>
         public void AutocompletePhrase(string currentCommand)
         {
-            var inputWithoutDirectory = currentCommand.Replace(_userCommandService.GetCommandPrompt(), string.Empty).Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            var inputWithoutDirectory = currentCommand.Replace(_userCommandService.GetCommandPrompt(), string.Empty).Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
             var userCommand = UserCommandService.EvaluateToken(inputWithoutDirectory.FirstOrDefault());
-            var pathToSearch = inputWithoutDirectory.LastOrDefault();
-            if (!_validAutoCompleteCommands.Contains(userCommand) || string.IsNullOrEmpty(pathToSearch))
+            var pathToSearch = inputWithoutDirectory.Skip(1).LastOrDefault() ?? string.Empty;
+            if (!_validAutoCompleteCommands.Contains(userCommand))
             {
-                OnInvalidAutocomplete?.Invoke();
+                OnInvalidAutocomplete?.Invoke(null);
                 return;
             }
 
-            // maintain the last input from the user during autocomplete
-            var isAbsoluteSearch = pathToSearch.StartsWith('/');
-            var isDeepRelativeSearch = !isAbsoluteSearch && pathToSearch.Trim('/').Contains('/');
-            var isDeepAbsoluteSearch = isAbsoluteSearch && pathToSearch.Trim('/').Contains('/');
-            if (!pathToSearch.EndsWith('/') && (isDeepRelativeSearch || isDeepAbsoluteSearch))
+            // find out what type of search the user is attempting to autocomplete
+            bool isRootSearch = pathToSearch.Equals(TerminalCharactersConstants.Separator.ToString());
+            bool isRelativeSearch = inputWithoutDirectory.Length >= 1 && !pathToSearch.EndsWith('/') && !pathToSearch.StartsWith('/');
+            bool isAbsoluteSearch = inputWithoutDirectory.Length == 2 && !string.IsNullOrEmpty(pathToSearch) && !pathToSearch.EndsWith('/') && pathToSearch.StartsWith('/');
+
+            bool isShallowRelativeSearch = isRelativeSearch && !string.IsNullOrEmpty(pathToSearch) && !pathToSearch.Trim('/').Contains('/');
+            bool isDeepRelativeSearch = isRelativeSearch && !string.IsNullOrEmpty(pathToSearch) && pathToSearch.Trim('/').Contains('/');
+            bool isDeepAbsoluteSearch = isAbsoluteSearch && pathToSearch.Trim('/').Contains('/');
+
+            bool isCompleteAbsolutePath = !isRootSearch && pathToSearch.StartsWith('/') && pathToSearch.EndsWith('/');
+            bool isCompleteRelativePath = !pathToSearch.StartsWith('/') && pathToSearch.EndsWith('/');
+
+            // listen to the last part of the path, if there are multiple slashes in the path
+            // i.e.: /system/co -> [hit tab] -> /system/config
+            if (isDeepRelativeSearch || isDeepAbsoluteSearch)
             {
                 _partialPath = pathToSearch.Split('/', StringSplitOptions.RemoveEmptyEntries).Last();
             }
-            else if (!pathToSearch.EndsWith('/') && isAbsoluteSearch)
+            // allow autocomplete from the root
+            // i.e.: / -> [hit tab] -> /system/
+            else if (isRootSearch)
             {
-                _partialPath = isAbsoluteSearch ? pathToSearch.TrimStart('/') : pathToSearch;
+                _partialPath = string.Empty;
+            }
+            // listen to the first part of an absolute path
+            // i.e.: /sy -> [hit tab] -> /system/
+            else if (isAbsoluteSearch)
+            {
+                _partialPath = pathToSearch.TrimStart('/');
+            }
+            // listen to the first part of a relative path
+            // i.e.: from /system -> con -> [hit tab] -> config/
+            else if (isShallowRelativeSearch)
+            {
+                _partialPath = pathToSearch;
+            }
+            // create new result if the result is already matched or not present
+            // i.e.: from /system -> config/ -> [hit tab] -> device/
+            else if (string.IsNullOrEmpty(pathToSearch))
+            {
+                _partialPath = string.Empty;
             }
 
             // determine which directory the autocomplete search begins from
-            DirectoryEntity directoryToSearch = isAbsoluteSearch ? _directoryService.GetRootDirectory() : _directoryService.GetCurrentDirectory();
+            DirectoryEntity directoryToSearch = (isAbsoluteSearch || isRootSearch || isCompleteAbsolutePath)
+                ? _directoryService.GetRootDirectory()
+                : _directoryService.GetCurrentDirectory();
             if (isDeepAbsoluteSearch)
             {
                 var directoryWithoutPartialPath = string.Join('/', pathToSearch.Split('/', StringSplitOptions.RemoveEmptyEntries).SkipLast(1));
-                directoryToSearch = _directoryService.GetAbsoluteDirectory(directoryWithoutPartialPath);
+                directoryToSearch = _directoryService.GetAbsoluteDirectory($"/{directoryWithoutPartialPath}");
             }
             if (isDeepRelativeSearch)
             {
@@ -99,27 +131,31 @@ namespace Terminal.Services
                 ? directoryToSearch.Entities
                 : directoryToSearch.Entities.Where(entity => entity.Name.StartsWith(_partialPath));
 
-            // if there are no autocomplete results and the user is searching with a partial path, do nothing
+            // if there are no autocomplete results and the user is searching with a partial path,
+            // list the directory contents then fill up the next input with the current command.
             if (!filteredEntities.Any())
             {
+                OnInvalidAutocomplete?.Invoke(_directoryService.GetAbsoluteDirectoryPath(directoryToSearch));
+                OnAutocomplete?.Invoke(currentCommand);
                 return;
             }
 
             // fill in the results of the autocomplete search, folders for change directory, and files for view or edit file
-            if (userCommand == UserCommand.ChangeDirectory || userCommand == UserCommand.ViewFile || userCommand == UserCommand.EditFile)
+            if (userCommand == UserCommand.ChangeDirectory || userCommand == UserCommand.ListDirectory || userCommand == UserCommand.ViewFile || userCommand == UserCommand.EditFile)
             {
-                filteredEntities = filteredEntities.Where(entity => entity.IsDirectory == (userCommand == UserCommand.ChangeDirectory));
+                filteredEntities = filteredEntities.Where(entity => entity.IsDirectory == (userCommand == UserCommand.ChangeDirectory || userCommand == UserCommand.ListDirectory));
             }
 
             DirectoryEntity matchingEntity = filteredEntities.FirstOrDefault();
             if (_autocompletedEntity != null)
             {
                 // wrap the autocomplete results
-                matchingEntity = filteredEntities.SkipWhile(p => p.Name != _autocompletedEntity.Name).Skip(1).FirstOrDefault() ?? filteredEntities.FirstOrDefault();
+                matchingEntity = filteredEntities.SkipWhile(p => p.Name != _autocompletedEntity.Name).Skip(1).FirstOrDefault()
+                    ?? filteredEntities.FirstOrDefault();
             }
 
             // determine which path to show as a result
-            var autoCompletedPath = isAbsoluteSearch
+            var autoCompletedPath = (isAbsoluteSearch || isRootSearch || isCompleteAbsolutePath)
                 ? _directoryService.GetAbsoluteEntityPath(matchingEntity)
                 : _directoryService.GetRelativeEntityPath(matchingEntity);
 

--- a/Services/UserCommandService.cs
+++ b/Services/UserCommandService.cs
@@ -146,34 +146,33 @@ namespace Terminal.Services
         /// A <see langword="string"/> filled with helpful information about the provided <paramref name="typeOfHelp"/>
         /// or <paramref name="userHelpContext"/>.
         /// </returns>
-        public string EvaluateHelpCommand(UserCommand? typeOfHelp = UserCommand.Help, string userHelpContext = null)
+        public string EvaluateHelpCommand(UserCommand typeOfHelp = UserCommand.Help, string userHelpContext = null)
         {
-            var allCommands = AllCommands;
-            if (allCommands.TryGetValue(userHelpContext, out Dictionary<string, string> helpContext))
+            if (!string.IsNullOrEmpty(userHelpContext) && AllCommands.TryGetValue(userHelpContext, out Dictionary<string, string> helpContext))
             {
                 return GetOutputFromTokens(helpContext);
             }
 
             return typeOfHelp switch
             {
-                UserCommand.Help => GetOutputFromTokens(allCommands["help"]),
-                UserCommand.Exit => GetOutputFromTokens(allCommands["exit"]),
-                UserCommand.Color => GetOutputFromTokens(allCommands["color"]),
-                UserCommand.Save => GetOutputFromTokens(allCommands["save"]),
-                UserCommand.Commands => GetOutputFromTokens(allCommands["commands"]),
-                UserCommand.ChangeDirectory => GetOutputFromTokens(allCommands["change"]),
-                UserCommand.ListDirectory => GetOutputFromTokens(allCommands["list"]),
-                UserCommand.ViewFile => GetOutputFromTokens(allCommands["view"]),
-                UserCommand.MakeFile => GetOutputFromTokens(allCommands["makefile"]),
-                UserCommand.MakeDirectory => GetOutputFromTokens(allCommands["makedirectory"]),
-                UserCommand.EditFile => GetOutputFromTokens(allCommands["edit"]),
-                UserCommand.ListHardware => GetOutputFromTokens(allCommands["listhardware"]),
-                UserCommand.ViewPermissions => GetOutputFromTokens(allCommands["viewpermissions"]),
-                UserCommand.ChangePermissions => GetOutputFromTokens(allCommands["changepermissions"]),
-                UserCommand.Date => GetOutputFromTokens(allCommands["date"]),
-                UserCommand.Time => GetOutputFromTokens(allCommands["time"]),
-                UserCommand.Now => GetOutputFromTokens(allCommands["now"]),
-                UserCommand.Network => GetOutputFromTokens(allCommands["network"]),
+                UserCommand.Help => GetOutputFromTokens(AllCommands["help"]),
+                UserCommand.Exit => GetOutputFromTokens(AllCommands["exit"]),
+                UserCommand.Color => GetOutputFromTokens(AllCommands["color"]),
+                UserCommand.Save => GetOutputFromTokens(AllCommands["save"]),
+                UserCommand.Commands => GetOutputFromTokens(AllCommands["commands"]),
+                UserCommand.ChangeDirectory => GetOutputFromTokens(AllCommands["change"]),
+                UserCommand.ListDirectory => GetOutputFromTokens(AllCommands["list"]),
+                UserCommand.ViewFile => GetOutputFromTokens(AllCommands["view"]),
+                UserCommand.MakeFile => GetOutputFromTokens(AllCommands["makefile"]),
+                UserCommand.MakeDirectory => GetOutputFromTokens(AllCommands["makedirectory"]),
+                UserCommand.EditFile => GetOutputFromTokens(AllCommands["edit"]),
+                UserCommand.ListHardware => GetOutputFromTokens(AllCommands["listhardware"]),
+                UserCommand.ViewPermissions => GetOutputFromTokens(AllCommands["viewpermissions"]),
+                UserCommand.ChangePermissions => GetOutputFromTokens(AllCommands["changepermissions"]),
+                UserCommand.Date => GetOutputFromTokens(AllCommands["date"]),
+                UserCommand.Time => GetOutputFromTokens(AllCommands["time"]),
+                UserCommand.Now => GetOutputFromTokens(AllCommands["now"]),
+                UserCommand.Network => GetOutputFromTokens(AllCommands["network"]),
                 _ => string.Empty
             };
         }
@@ -200,9 +199,7 @@ namespace Terminal.Services
             commandsExecutableFile.Contents = string.Concat(commandsContentsMinusReplacement, DirectoryConstants.HelpLineSeparator, "[COMMANDS", DirectoryConstants.HelpKeyValueSeparator, sortedCommands, "]");
         }
 
-        private static string GetOutputFromTokens(Dictionary<string, string> outputTokens)
-        {
-            return $"\n{string.Join("\n\n", outputTokens.Select(token => string.Join('\n', token.Key, token.Value)))}\n\n";
-        }
+        private static string GetOutputFromTokens(Dictionary<string, string> outputTokens) =>
+            $"\n{string.Join("\n\n", outputTokens.Select(token => string.Join('\n', token.Key, token.Value)))}\n\n";
     }
 }


### PR DESCRIPTION
This PR not only fixes relative autocomplete... now you can `ls /` to see all files in the root directory!

This came up as a result of implementing the better version of autocomplete, because if you tab and don't have any matching entities to show, it's best to show the entities of the contextual directory while autocompleting.

Also there was a small fix to the keyboard sound repeating while a key was pressed, now it will only sound on "non-echoed" keyboard input (keyboard input that wasn't responsible for triggering the last input event).