### PR TITLE
Listen to volume setting from "user.conf" file

### DIFF
--- a/Constants/DirectoryConstants.cs
+++ b/Constants/DirectoryConstants.cs
@@ -265,7 +265,7 @@ namespace Terminal.Constants
 
             userDirectory.Entities = new()
             {
-                new DirectoryFolder() { Name = "config", ParentId = userDirectory.Id, Permissions = _userReadWritePermissions },
+                configDirectory,
                 homeDirectory,
                 new DirectoryFolder() { Name = "programs", ParentId = userDirectory.Id, Permissions = _userReadWritePermissions },
             };

--- a/Extensions/NumberExtensions.cs
+++ b/Extensions/NumberExtensions.cs
@@ -1,0 +1,36 @@
+﻿namespace Terminal.Extensions
+{
+    /// <summary>
+    /// A <see langword="static"/> collection of extension methods for manipulating numbers.
+    /// </summary>
+    public static class NumberExtensions
+    {
+        /// <summary>
+        /// Converts the <paramref name="valueToConvert"/> from the original range (<paramref name="originalStart"/> - <paramref name="originalEnd"/>)
+        /// to the new range (<paramref name="newStart"/> - <paramref name="newEnd"/>).
+        /// </summary>
+        /// <param name="valueToConvert">
+        /// The value to convert.
+        /// </param>
+        /// <param name="originalStart">
+        /// The start of the original range.
+        /// </param>
+        /// <param name="originalEnd">
+        /// The end of the original range.
+        /// </param>
+        /// <param name="newStart">
+        /// The start of the new range.
+        /// </param>
+        /// <param name="newEnd">
+        /// The end of the new range.
+        /// </param>
+        /// <returns>
+        /// The <paramref name="valueToConvert"/> converted to be within the new range (<paramref name="newStart"/> - <paramref name="newEnd"/>).
+        /// </returns>
+        public static int ConvertRange(this int valueToConvert, int originalStart, int originalEnd, int newStart, int newEnd)
+        {
+            double scale = (double)(newEnd - newStart) / (originalEnd - originalStart);
+            return (int)(newStart + ((valueToConvert - originalStart) * scale));
+        }
+    }
+}

--- a/Inputs/FileInput.cs
+++ b/Inputs/FileInput.cs
@@ -37,6 +37,7 @@ namespace Terminal.Inputs
         public delegate void CloseFileCommandEventHandler(string closeMessage);
 
         private PersistService _persistService;
+        private ConfigService _configService;
         private Theme _defaultUserInputTheme;
         private ScrollableContainer _scrollableContainer;
         private VBoxContainer _fileEditorContainer;
@@ -48,6 +49,7 @@ namespace Terminal.Inputs
         public override void _Ready()
         {
             _persistService = GetNode<PersistService>(ServicePathConstants.PersistServicePath);
+            _configService = GetNode<ConfigService>(ServicePathConstants.ConfigServicePath);
             _defaultUserInputTheme = GD.Load<Theme>(ThemePathConstants.MonospaceFontThemePath);
             _scrollableContainer = GetNode<ScrollableContainer>("%ScrollableContainer");
             _fileEditorContainer = GetParent<VBoxContainer>();
@@ -113,6 +115,9 @@ namespace Terminal.Inputs
 
         /// <summary>
         /// Persists the contents of the file editor into the provided <paramref name="file"/>.
+        /// <para>
+        /// Also updates configuration information if the saved file has the "conf" extension.
+        /// </para>
         /// </summary>
         /// <param name="file">
         /// The file to persist the file editor content into.
@@ -123,6 +128,12 @@ namespace Terminal.Inputs
         public void SaveFile(DirectoryEntity file, bool closeEditor)
         {
             file.Contents = Text;
+
+            if(file.Extension.Equals("conf"))
+            {
+                _configService.UpdateConfigInformation();
+            }
+
             if(closeEditor)
             {
                 CloseFileEditor();

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ terminal_os is a terminal game written in the Godot engine using .NET 8 and C#.
     - Get the current time using the `time` command
 - Get the current networking information using the `network` command
     - Use the `help network` command to get information about valid arguments
-- Add new colors to the terminal by using `edit` on the `/system/config/color.conf` file, and adding a name and hex value
+- Modify config values in real-time by using `edit` on any `.conf` file
+    - `/system/config/color.conf` to create/remove colors
+    - `/users/user/config/user.conf` to modify volume
 - Contextual autocomplete for commands by pressing the tab key
 - Save your game by using the `save` command
 - Exit the terminal using the `exit` command


### PR DESCRIPTION
This PR will introduce the ability to modify the volume of the game by setting a value for the "volume" key in the `/users/user/user.conf` file.

It will also make sure to only update the `ConfigService.Volume` application-wide when a file that has the `.conf` extension is saved.