### PR TITLE
Ensure empty newlines don't break color.conf

### DIFF
--- a/Services/ConfigService.cs
+++ b/Services/ConfigService.cs
@@ -97,7 +97,7 @@ namespace Terminal.Services
                 var keyAndValue = cfd.Split(':');
                 if(keyAndValue.Length != 2)
                 {
-                    return default;
+                    return new KeyValuePair<string, string>(string.Empty, string.Empty);
                 }
 
                 return new KeyValuePair<string, string>(keyAndValue.First(), keyAndValue.Last());


### PR DESCRIPTION
Now when the color config file is saved via the `ConfigService`, the newlines are discarded.