### PR TITLE
Reduce scope for massive UserInput and ScrollableContainer files

### DIFF
--- a/Constants/ServicePathConstants.cs
+++ b/Constants/ServicePathConstants.cs
@@ -42,5 +42,10 @@ namespace Terminal.Constants
         /// The <see cref="NetworkService"/> single path in Godot.
         /// </summary>
         public const string NetworkServicePath = "/root/NetworkService";
+
+        /// <summary>
+        /// The <see cref="UserService"/> single path in Godot.
+        /// </summary>
+        public const string UserServicePath = "/root/UserService";
     }
 }

--- a/Constants/ServicePathConstants.cs
+++ b/Constants/ServicePathConstants.cs
@@ -34,18 +34,23 @@ namespace Terminal.Constants
         public const string ScreenNavigatorServicePath = "/root/ScreenNavigator";
 
         /// <summary>
-        /// The <see cref="AutoCompleteService"/> single path in Godot.
+        /// The <see cref="AutoCompleteService"/> singleton path in Godot.
         /// </summary>
         public const string AutoCompleteServicePath = "/root/AutoCompleteService";
 
         /// <summary>
-        /// The <see cref="NetworkService"/> single path in Godot.
+        /// The <see cref="NetworkService"/> singleton path in Godot.
         /// </summary>
         public const string NetworkServicePath = "/root/NetworkService";
 
         /// <summary>
-        /// The <see cref="UserService"/> single path in Godot.
+        /// The <see cref="UserService"/> singleton path in Godot.
         /// </summary>
         public const string UserServicePath = "/root/UserService";
+
+        /// <summary>
+        /// The <see cref="PermissionsService"/> singleton path in Godot.
+        /// </summary>
+        public const string PermissionsServicePath = "/root/PermissionsService";
     }
 }

--- a/Containers/ScrollableContainer.cs
+++ b/Containers/ScrollableContainer.cs
@@ -93,8 +93,6 @@ namespace Terminal.Containers
             newUserInput.ListDirectoryCommand += ListDirectoryCommandResponse;
             newUserInput.EditFileCommand += EditFileCommandResponse;
             newUserInput.ListHardwareCommand += ListHardwareCommandResponse;
-            newUserInput.ViewPermissionsCommand += ViewPermissionsCommandResponse;
-            newUserInput.ChangePermissionsCommand += ChangePermissionsCommandResponse;
             newUserInput.NetworkCommand += NetworkCommandResponse;
 
             AddChild(newUserInput);
@@ -277,54 +275,6 @@ namespace Terminal.Containers
 
             //var deviceList = hardwareResponse.Select(hwr => $"{hwr.Key}\n{string.Concat(hwr.Key.Select(hwrc => '-'))}\n{string.Join("\n\n", hwr.Value.Select(hwri => string.Join('\n', hwri)))}");
             CreateResponse(string.Join("\n", hardwareColumnsOutput.Select(hardwareOutputTuple => $"{hardwareOutputTuple.Item1,-15}{hardwareOutputTuple.Item2,-15}{hardwareOutputTuple.Item3}")));
-        }
-
-        private void ViewPermissionsCommandResponse(string entityName)
-        {
-            var entity = entityName.StartsWith('/')
-                ? _directoryService.GetAbsoluteFile(entityName) ?? _directoryService.GetAbsoluteDirectory(entityName.TrimEnd('/'))
-                : _directoryService.GetRelativeFile(entityName) ?? _directoryService.GetRelativeDirectory(entityName.TrimEnd('/'));
-
-            if (entityName == "/" || entityName == "root")
-            {
-                entity = _directoryService.GetRootDirectory();
-            }
-
-            if (entity == null)
-            {
-                CreateResponse($"No folder or file with the name \"{entityName}\" exists.");
-                return;
-            }
-
-            CreateResponse(PermissionsService.GetPermissionDisplay(entity.Permissions));
-        }
-
-        private void ChangePermissionsCommandResponse(string entityName, string newPermissionSet)
-        {
-            var entity = entityName.StartsWith('/')
-                ? _directoryService.GetAbsoluteFile(entityName) ?? _directoryService.GetAbsoluteDirectory(entityName.TrimEnd('/'))
-                : _directoryService.GetRelativeFile(entityName) ?? _directoryService.GetRelativeDirectory(entityName.TrimEnd('/'));
-
-            if (entityName == "/" || entityName == "root")
-            {
-                entity = _directoryService.GetRootDirectory();
-            }
-
-            if (entity == null)
-            {
-                CreateResponse($"No folder or file with the name \"{entityName}\" exists.");
-                return;
-            }
-
-            var newPermissions = PermissionsService.GetPermissionFromInput(newPermissionSet);
-            if (newPermissions == null)
-            {
-                CreateResponse($"Permissions set \"{newPermissionSet}\" was in an incorrect format. Permission sets are 6 bits (011011).");
-                return;
-            }
-
-            entity.Permissions = newPermissions;
-            CreateResponse($"\"{entityName}\" permissions updated to {PermissionsService.GetPermissionDisplay(entity.Permissions)}");
         }
 
         private void NetworkCommandResponse()

--- a/Inputs/UserInput.cs
+++ b/Inputs/UserInput.cs
@@ -37,21 +37,6 @@ namespace Terminal.Inputs
         public delegate void KnownCommandEventHandler(string message);
 
         /// <summary>
-        /// The <see cref="Signal"/> that broadcasts when the <see cref="UserCommand.Color"/> command is invoked.
-        /// </summary>
-        /// <param name="colorName">
-        /// The name of the <see cref="Color"/> to change the console to.
-        /// </param>
-        [Signal]
-        public delegate void ColorCommandEventHandler(string colorName);
-
-        /// <summary>
-        /// The <see cref="Signal"/> that broadcasts when the <see cref="UserCommand.Save"/> command is invoked.
-        /// </summary>
-        [Signal]
-        public delegate void SaveCommandEventHandler();
-
-        /// <summary>
         /// The <see cref="Signal"/> that broadcasts when the <see cref="UserCommand.ListDirectory"/> command is invoked.
         /// </summary>
         /// <param name="directoryToList">
@@ -59,33 +44,6 @@ namespace Terminal.Inputs
         /// </param>
         [Signal]
         public delegate void ListDirectoryCommandEventHandler(string directoryToList);
-
-        /// <summary>
-        /// The <see cref="Signal"/> that broadcasts when the <see cref="UserCommand.ChangeDirectory"/> command is invoked.
-        /// </summary>
-        /// <param name="newDirectory">
-        /// The name of the new current directory.
-        /// </param>
-        [Signal]
-        public delegate void ChangeDirectoryCommandEventHandler(string newDirectory);
-
-        /// <summary>
-        /// The <see cref="Signal"/> that broadcasts when the <see cref="UserCommand.MakeFile"/> command is invoked.
-        /// </summary>
-        /// <param name="fileName">
-        /// The name of the new file to make.
-        /// </param>
-        [Signal]
-        public delegate void MakeFileCommandEventHandler(string fileName);
-
-        /// <summary>
-        /// The <see cref="Signal"/> that broadcasts when the <see cref="UserCommand.MakeDirectory"/> command is invoked.
-        /// </summary>
-        /// <param name="directoryName">
-        /// The name of the new directory to make.
-        /// </param>
-        [Signal]
-        public delegate void MakeDirectoryCommandEventHandler(string directoryName);
 
         /// <summary>
         /// The <see cref="Signal"/> that broadcasts when the <see cref="UserCommand.EditFile"/> command is invoked.
@@ -129,27 +87,6 @@ namespace Terminal.Inputs
         [Signal]
         public delegate void NetworkCommandEventHandler();
 
-        /// <summary>
-        /// The <see cref="Signal"/> that broadcasts when the <see cref="UserCommand.DeleteFile"/> command is invoked.
-        /// </summary>
-        /// <param name="fileName">
-        /// The name of the file to delete.
-        /// </param>
-        [Signal]
-        public delegate void DeleteFileCommandEventHandler(string fileName);
-
-        /// <summary>
-        /// The <see cref="Signal"/> that broadcasts when the <see cref="UserCommand.DeleteDirectory"/> command is invoked.
-        /// </summary>
-        /// <param name="directoryName">
-        /// The name of the directory to delete.
-        /// </param>
-        /// <param name="arguments">
-        /// A list of arguments provided with the <see cref="UserCommand.DeleteDirectory"/> command.
-        /// </param>
-        [Signal]
-        public delegate void DeleteDirectoryCommandEventHandler(string directoryName, string[] arguments);
-
         private static readonly List<UserCommand> _commandsThatNeedAdditionalArguments = new()
         {
             UserCommand.Color,
@@ -184,8 +121,10 @@ namespace Terminal.Inputs
         private PersistService _persistService;
         private UserCommandService _userCommandService;
         private DirectoryService _directoryService;
+        private ConfigService _configService;
         private AutoCompleteService _autoCompleteService;
         private NetworkService _networkService;
+        private UserService _userService;
         private bool _hasFocus = false;
         private int _commandMemoryIndex;
 
@@ -193,9 +132,11 @@ namespace Terminal.Inputs
         {
             _userCommandService = GetNode<UserCommandService>(ServicePathConstants.UserCommandServicePath);
             _directoryService = GetNode<DirectoryService>(ServicePathConstants.DirectoryServicePath);
+            _configService = GetNode<ConfigService>(ServicePathConstants.ConfigServicePath);
             _persistService = GetNode<PersistService>(ServicePathConstants.PersistServicePath);
             _autoCompleteService = GetNode<AutoCompleteService>(ServicePathConstants.AutoCompleteServicePath);
             _networkService = GetNode<NetworkService>(ServicePathConstants.NetworkServicePath);
+            _userService = GetNode<UserService>(ServicePathConstants.UserServicePath);
             _keyboardSounds = GetTree().Root.GetNode<KeyboardSounds>(KeyboardSounds.AbsolutePath);
             _commandMemoryIndex = _persistService.CommandMemory.Count;
 
@@ -317,11 +258,11 @@ namespace Terminal.Inputs
             return userCommand switch
             {
                 UserCommand.Help or UserCommand.Commands => QualifyAndEvaluateHelpCommand(userCommand, parsedTokens),
-                UserCommand.ChangeDirectory => () => ChangeDirectory(parsedTokens.Take(2).Last()),
+                UserCommand.ChangeDirectory => () => CreateSimpleTerminalResponse(_directoryService.ChangeDirectory(parsedTokens.Take(2).Last())),
                 UserCommand.ListDirectory => () => ListDirectory(parsedTokens.Skip(1).Take(1).FirstOrDefault()),
-                UserCommand.ViewFile => () => ViewFile(parsedTokens.Take(2).Last()),
-                UserCommand.MakeFile => () => MakeFile(parsedTokens.Take(2).Last()),
-                UserCommand.MakeDirectory => () => MakeDirectory(parsedTokens.Take(2).Last()),
+                UserCommand.ViewFile => () => CreateSimpleTerminalResponse(_directoryService.ViewFile(parsedTokens.Take(2).Last())),
+                UserCommand.MakeFile => () => CreateSimpleTerminalResponse(_directoryService.CreateFile(parsedTokens.Take(2).Last())),
+                UserCommand.MakeDirectory => () => CreateSimpleTerminalResponse(_directoryService.CreateDirectory(parsedTokens.Take(2).Last())),
                 UserCommand.EditFile => () => EditFile(parsedTokens.Take(2).Last()),
                 UserCommand.ListHardware => () => ListHardware(),
                 UserCommand.ViewPermissions => () => ViewPermissions(parsedTokens.Take(2).Last()),
@@ -330,21 +271,21 @@ namespace Terminal.Inputs
                 UserCommand.Time => () => CreateSimpleTerminalResponse(DateTime.UtcNow.AddYears(250).ToLongTimeString()),
                 UserCommand.Now => () => CreateSimpleTerminalResponse(string.Join(", ", DateTime.UtcNow.AddYears(250).ToLongTimeString(), DateTime.UtcNow.AddYears(250).ToLongDateString())),
                 UserCommand.Network => () => _networkService.ShowNetworkInformation(parsedTokens.Skip(1)),
-                UserCommand.Color => () => ChangeColor(parsedTokens.Take(2).Last()),
-                UserCommand.Save => () => SaveProgress(),
+                UserCommand.Color => () => CreateSimpleTerminalResponse(ChangeColor(parsedTokens.Take(2).Last())),
+                UserCommand.Save => () => CreateSimpleTerminalResponse(SaveProgress()),
                 UserCommand.Exit => () => Exit(),
-                UserCommand.DeleteFile => () => DeleteFile(parsedTokens.Take(2).Last()),
-                UserCommand.DeleteDirectory => () => DeleteDirectory(parsedTokens.Take(2).Last(), parsedTokens.Skip(2)),
-                UserCommand.MoveFile => () => MoveFile(parsedTokens.Skip(1)),
-                UserCommand.MoveDirectory => () => MoveDirectory(parsedTokens.Skip(1)),
+                UserCommand.DeleteFile => () => CreateSimpleTerminalResponse(_directoryService.DeleteFile(parsedTokens.Take(2).Last())),
+                UserCommand.DeleteDirectory => () => CreateSimpleTerminalResponse(_directoryService.DeleteDirectory(parsedTokens.Take(2).Last(), parsedTokens.Skip(2))),
+                UserCommand.MoveFile => () => CreateSimpleTerminalResponse(_directoryService.MoveFile(parsedTokens.Skip(1))),
+                UserCommand.MoveDirectory => () => CreateSimpleTerminalResponse(_directoryService.MoveDirectory(parsedTokens.Skip(1))),
                 UserCommand.Ping => () => StartPing(parsedTokens.Take(2).Last(), parsedTokens.Skip(2)),
-                UserCommand.MakeUser => () => MakeUser(parsedTokens.Skip(1)),
-                UserCommand.DeleteUser => () => DeleteUser(parsedTokens.Skip(1)),
-                UserCommand.MakeGroup => () => MakeGroup(parsedTokens.Skip(1)),
-                UserCommand.DeleteGroup => () => DeleteGroup(parsedTokens.Skip(1)),
-                UserCommand.AddUserToGroup => () => AddUserToGroup(parsedTokens.Skip(1)),
-                UserCommand.DeleteUserFromGroup => () => DeleteUserFromGroup(parsedTokens.Skip(1)),
-                UserCommand.ViewGroup => () => ViewUserGroup(parsedTokens.Take(2).Last()),
+                UserCommand.MakeUser => () => CreateSimpleTerminalResponse(_userService.MakeUser(parsedTokens.Skip(1))),
+                UserCommand.DeleteUser => () => CreateSimpleTerminalResponse(_userService.DeleteUser(parsedTokens.Skip(1))),
+                UserCommand.MakeGroup => () => CreateSimpleTerminalResponse(_userService.MakeGroup(parsedTokens.Skip(1))),
+                UserCommand.DeleteGroup => () => CreateSimpleTerminalResponse(_userService.DeleteGroup(parsedTokens.Skip(1))),
+                UserCommand.AddUserToGroup => () => CreateSimpleTerminalResponse(_userService.AddUserToGroup(parsedTokens.Skip(1))),
+                UserCommand.DeleteUserFromGroup => () => CreateSimpleTerminalResponse(_userService.DeleteUserFromGroup(parsedTokens.Skip(1))),
+                UserCommand.ViewGroup => () => CreateSimpleTerminalResponse(_userService.ViewUserGroup(parsedTokens.Take(2).Last())),
                 _ => () => CreateSimpleTerminalResponse($"\"{parsedTokens.First()}\" is an unknown command. Use \"commands\" to get a list of available commands.")
             };
         }
@@ -363,93 +304,44 @@ namespace Terminal.Inputs
 
         private void PlayKeyboardSound() => _keyboardSounds.PlayKeyboardSound();
 
-        private void CreateSimpleTerminalResponse(string message) => EmitSignal(SignalName.KnownCommand, message);
+        private void CreateSimpleTerminalResponse(string message)
+        {
+            if (string.IsNullOrEmpty(message))
+            {
+                GD.Print("Attempted to create a simple terminal response, but the message provided was null or empty.");
+                return;
+            }
 
-        private void SaveProgress() => EmitSignal(SignalName.SaveCommand);
+            EmitSignal(SignalName.KnownCommand, message);
+        }
+
+        private string SaveProgress()
+        {
+            _persistService.SaveGame();
+            return "Progress saved.";
+        }
 
         private void Exit() => GetTree().Quit();
 
-        private void ChangeColor(string newColor) => EmitSignal(SignalName.ColorCommand, newColor);
-
-        private void ChangeDirectory(string newDirectory)
+        private string ChangeColor(string newColorName)
         {
-            var directory = newDirectory.ToLowerInvariant() switch
+            if (!_configService.Colors.TryGetValue(newColorName, out Color newColor))
             {
-                ".." => _directoryService.GetParentDirectory(_directoryService.GetCurrentDirectory()),
-                "." or "./" => _directoryService.GetCurrentDirectory(),
-                "~" => _directoryService.GetHomeDirectory(),
-                "root" or "/" => _directoryService.GetRootDirectory(),
-                _ => newDirectory.StartsWith(TerminalCharactersConstants.Separator)
-                    ? _directoryService.GetAbsoluteDirectory(newDirectory.TrimEnd(TerminalCharactersConstants.Separator))
-                    : newDirectory.Contains(TerminalCharactersConstants.HomeDirectory)
-                        ? _directoryService.GetHomeDirectory().FindDirectory(newDirectory.Split(TerminalCharactersConstants.HomeDirectory).LastOrDefault()?.TrimEnd(TerminalCharactersConstants.Separator))
-                        : _directoryService.GetRelativeDirectory(newDirectory.TrimEnd(TerminalCharactersConstants.Separator))
-            };
-
-            if (directory == null)
-            {
-                EmitSignal(SignalName.KnownCommand, $"\"{newDirectory}\" is not a directory.");
-                return;
+                var sortedColors = string.Join(", ", _configService.Colors.Keys.OrderBy(key => key).Select(key => key));
+                return $"Invalid color option. Possible color options are: {sortedColors}.";
             }
 
-            if (!directory.Permissions.Contains(Permission.UserRead))
+            if (!_configService.ExecutableColors.TryGetValue(newColorName, out Color executableColor))
             {
-                EmitSignal(SignalName.KnownCommand, $"Insufficient permissions to enter the \"{_directoryService.GetAbsoluteDirectoryPath(directory)}\" directory.");
-                return;
+                return $"Unable to find executable color mapping for '{newColorName}'.";
             }
 
-            _directoryService.SetCurrentDirectory(directory);
+            _persistService.CurrentColor = newColor;
+            _persistService.ExecutableColor = executableColor;
+            return $"Color updated to {newColorName}.";
         }
 
         private void ListDirectory(string directoryToList = null) => EmitSignal(SignalName.ListDirectoryCommand, directoryToList);
-
-        private void ViewFile(string fileName)
-        {
-            var file = _directoryService.GetRelativeFile(fileName);
-            if(file == null)
-            {
-                EmitSignal(SignalName.KnownCommand, $"\"{fileName}\" does not exist.");
-                return;
-            }
-
-            if(file.Permissions.Contains(Permission.AdminExecutable) || file.Permissions.Contains(Permission.UserExecutable))
-            {
-                EmitSignal(SignalName.KnownCommand, $"\"{fileName}\" is an executable.");
-                return;
-            }
-
-            if (!file.Permissions.Contains(Permission.UserRead))
-            {
-                EmitSignal(SignalName.KnownCommand, $"Insufficient permissions to view the \"{fileName}\" file.");
-                return;
-            }
-
-            EmitSignal(SignalName.KnownCommand, file.Contents);
-        }
-
-        private void MakeFile(string fileName)
-        {
-            var currentDirectory = _directoryService.GetCurrentDirectory();
-            if (!currentDirectory.Permissions.Contains(Permission.UserWrite))
-            {
-                EmitSignal(SignalName.KnownCommand, $"Insufficient permissions to create a file in the current directory.");
-                return;
-            }
-
-            EmitSignal(SignalName.MakeFileCommand, fileName);
-        }
-
-        private void MakeDirectory(string directoryName)
-        {
-            var currentDirectory = _directoryService.GetCurrentDirectory();
-            if (!currentDirectory.Permissions.Contains(Permission.UserWrite))
-            {
-                EmitSignal(SignalName.KnownCommand, $"Insufficient permissions to create a directory in the current directory.");
-                return;
-            }
-
-            EmitSignal(SignalName.MakeDirectoryCommand, directoryName);
-        }
 
         private void EditFile(string fileName)
         {
@@ -537,401 +429,15 @@ namespace Terminal.Inputs
             return () => CreateSimpleTerminalResponse(helpText);
         }
 
-        private void DeleteFile(string fileName)
-        {
-            var currentDirectory = _directoryService.GetCurrentDirectory();
-            if (!currentDirectory.Permissions.Contains(Permission.UserWrite))
-            {
-                EmitSignal(SignalName.KnownCommand, $"Insufficient permissions to delete \"{fileName}\" in the current directory.");
-                return;
-            }
+        private void StartPing(string address, IEnumerable<string> arguments) => _networkService.StartPingResponse(address, arguments);
 
-            if (string.IsNullOrEmpty(fileName))
-            {
-                GD.PrintErr("File can't be deleted without a name.");
-                return;
-            }
-
-            var existingFile = _directoryService.GetRelativeFile(fileName);
-            if (existingFile == null)
-            {
-                EmitSignal(SignalName.KnownCommand, $"No file with the name of \"{fileName}\" exists.");
-                return;
-            }
-
-            _directoryService.DeleteEntity(existingFile);
-            EmitSignal(SignalName.KnownCommand, $"\"{fileName}\" deleted.");
-        }
-
-        private void DeleteDirectory(string directoryName, IEnumerable<string> arguments)
-        {
-            var currentDirectory = _directoryService.GetCurrentDirectory();
-            if (!currentDirectory.Permissions.Contains(Permission.UserWrite))
-            {
-                EmitSignal(SignalName.KnownCommand, $"Insufficient permissions to delete \"{directoryName}\" in the current directory.");
-                return;
-            }
-
-            if (string.IsNullOrEmpty(directoryName))
-            {
-                GD.PrintErr("Directory can't be deleted without a name.");
-                return;
-            }
-
-            var existingDirectory = _directoryService.GetRelativeDirectory(directoryName);
-            if (existingDirectory == null)
-            {
-                EmitSignal(SignalName.KnownCommand, $"No folder with the name of \"{directoryName}\" exists.");
-                return;
-            }
-
-            var recurse = arguments.Contains("-r") || arguments.Contains("--recurse");
-            if(recurse == false && existingDirectory.Entities.Any())
-            {
-                EmitSignal(SignalName.KnownCommand, $"Cannot delete the \"{directoryName}\" directory, it has files or folders in it.");
-                return;
-            }
-
-            _directoryService.DeleteEntity(existingDirectory);
-            EmitSignal(SignalName.KnownCommand, $"\"{directoryName}\" deleted.");
-        }
-
-        private void StartPing(string address, IEnumerable<string> arguments)
-        {
-            _networkService.StartPingResponse(address, arguments);
-        }
-
-        private void PingResponse(string pingMessage)
-        {
-            CreateSimpleTerminalResponse(pingMessage);
-        }
+        private void PingResponse(string pingMessage) => CreateSimpleTerminalResponse(pingMessage);
 
         private void FinishPing(string message)
         {
             EmitSignal(SignalName.KnownCommand, message);
             EmitSignal(SignalName.Evaluated);
             UnsubscribeAndStopInput();
-        }
-
-        private void MoveFile(IEnumerable<string> arguments)
-        {
-            var fileName = arguments.FirstOrDefault();
-            if(string.IsNullOrEmpty(fileName))
-            {
-                EmitSignal(SignalName.KnownCommand, $"Cannot move file without a file name.");
-                return;
-            }
-
-            var destinationPath = arguments.Skip(1).FirstOrDefault();
-            if (string.IsNullOrEmpty(destinationPath))
-            {
-                EmitSignal(SignalName.KnownCommand, $"Cannot move file without a destination.");
-                return;
-            }
-
-            var fileToMove = _directoryService.GetRelativeFile(fileName);
-            if(fileName.Trim('/').Contains('/'))
-            {
-                var fileNameWithoutPath = fileName.Split('/').LastOrDefault();
-                var filePath = fileName.Split('/').SkipLast(1);
-                fileToMove = _directoryService.GetRelativeDirectory(string.Join('/', filePath)).FindFile(fileNameWithoutPath);
-            }
-            if(fileToMove == null)
-            {
-                EmitSignal(SignalName.KnownCommand, $"Cannot move, file \"{fileName}\" does not exist in the current directory.");
-                return;
-            }
-
-            var destinationDirectory = _directoryService.GetAbsoluteDirectory(destinationPath.TrimEnd('/'));
-            if (destinationDirectory == null)
-            {
-                EmitSignal(SignalName.KnownCommand, $"Cannot move, destination folder \"{destinationDirectory}\" does not exist.");
-                return;
-            }
-
-            _directoryService.MoveEntity(fileToMove, destinationDirectory);
-            EmitSignal(SignalName.KnownCommand, $"\"{fileToMove}\" moved to \"{destinationDirectory}\".");
-        }
-
-        private void MoveDirectory(IEnumerable<string> arguments)
-        {
-            var directoryToMovePath = arguments.FirstOrDefault();
-            if (string.IsNullOrEmpty(directoryToMovePath))
-            {
-                EmitSignal(SignalName.KnownCommand, $"Cannot move directory without a directory name.");
-                return;
-            }
-
-            var destinationPath = arguments.Skip(1).FirstOrDefault();
-            if (string.IsNullOrEmpty(destinationPath))
-            {
-                EmitSignal(SignalName.KnownCommand, $"Cannot move directory without a destination.");
-                return;
-            }
-
-            var directoryToMove = _directoryService.GetRelativeDirectory(directoryToMovePath);
-            if (directoryToMove == null)
-            {
-                EmitSignal(SignalName.KnownCommand, $"Cannot move, directory \"{directoryToMove}\" does not exist in the current directory.");
-                return;
-            }
-
-            var destinationDirectory = _directoryService.GetAbsoluteDirectory(destinationPath);
-            if (destinationDirectory == null)
-            {
-                EmitSignal(SignalName.KnownCommand, $"Cannot move, destination folder \"{destinationDirectory}\" does not exist.");
-                return;
-            }
-
-            _directoryService.MoveEntity(directoryToMove, destinationDirectory);
-            EmitSignal(SignalName.KnownCommand, $"\"{directoryToMove}\" moved to \"{destinationDirectory}\".");
-        }
-
-        private void MakeUser(IEnumerable<string> arguments)
-        {
-            var userName = arguments.FirstOrDefault();
-            if(string.IsNullOrEmpty(userName))
-            {
-                GD.Print($"Attempted to make the new user, but user name was not provided.");
-                return;
-            }
-
-            var rootUsersDirectory = _directoryService.GetRootDirectory().FindDirectory("users");
-            if(rootUsersDirectory == null)
-            {
-                EmitSignal(SignalName.KnownCommand, $"Attempted to make the new user \"{userName}\", but there was no root /users/ directory.");
-                return;
-            }
-
-            var newUserDirectoryExists = rootUsersDirectory.FindDirectory(userName) != null;
-            if(newUserDirectoryExists)
-            {
-                EmitSignal(SignalName.KnownCommand, $"Attempted to make the new user \"{userName}\", but it already existed.");
-                return;
-            }
-
-            var newUserDirectory = DirectoryConstants.GetDefaultUserDirectory(rootUsersDirectory, userName);
-            rootUsersDirectory.Entities.Add(newUserDirectory);
-            EmitSignal(SignalName.KnownCommand, $"\"{userName}\" user created.");
-        }
-
-        private void DeleteUser(IEnumerable<string> arguments)
-        {
-            var userName = arguments.FirstOrDefault();
-            if(string.IsNullOrEmpty(userName))
-            {
-                GD.Print($"Attempted to delete a user, but user name was not provided.");
-                return;
-            }
-
-            var rootUsersDirectory = _directoryService.GetRootDirectory().FindDirectory("users");
-            if (rootUsersDirectory == null)
-            {
-                EmitSignal(SignalName.KnownCommand, $"Attempted to remove the \"{userName}\" user, but there was no root /users/ directory.");
-                return;
-            }
-
-            var userDirectoryToRemove = rootUsersDirectory.FindDirectory(userName);
-            if (userDirectoryToRemove == null)
-            {
-                EmitSignal(SignalName.KnownCommand, $"Attempted to remove the \"{userName}\" user, but it does not exist.");
-                return;
-            }
-
-            rootUsersDirectory.Entities.Remove(userDirectoryToRemove);
-            EmitSignal(SignalName.KnownCommand, $"\"{userName}\" user removed.");
-        }
-
-        private void MakeGroup(IEnumerable<string> arguments)
-        {
-            var groupName = arguments.FirstOrDefault();
-            if (string.IsNullOrEmpty(groupName))
-            {
-                GD.Print($"Attempted to make a user group, but group name was not provided.");
-                return;
-            }
-
-            var rootUserGroupsDirectory = _directoryService.GetRootDirectory().FindDirectory("users/groups");
-            if (rootUserGroupsDirectory == null)
-            {
-                EmitSignal(SignalName.KnownCommand, $"Attempted to add the \"{groupName}\" user group, but there was no root /users/ directory.");
-                return;
-            }
-
-            var groupDirectoryExists = rootUserGroupsDirectory.FindDirectory(groupName) != null;
-            if (groupDirectoryExists)
-            {
-                EmitSignal(SignalName.KnownCommand, $"Attempted to make the new user group \"{groupName}\", but it already existed.");
-                return;
-            }
-
-            DirectoryFolder newUserGroupFolder = new()
-            {
-                Name = groupName,
-                ParentId = rootUserGroupsDirectory.Id,
-                Permissions = new() { Permission.AdminRead, Permission.AdminWrite, Permission.UserRead, Permission.UserWrite }
-            };
-            rootUserGroupsDirectory.Entities.Add(newUserGroupFolder);
-            EmitSignal(SignalName.KnownCommand, $"\"{groupName}\" user group created.");
-        }
-
-        private void DeleteGroup(IEnumerable<string> arguments)
-        {
-            var groupName = arguments.FirstOrDefault();
-            if (string.IsNullOrEmpty(groupName))
-            {
-                GD.Print($"Attempted to delete a user group, but group name was not provided.");
-                return;
-            }
-
-            var rootUserGroupsDirectory = _directoryService.GetRootDirectory().FindDirectory("users/groups");
-            if (rootUserGroupsDirectory == null)
-            {
-                EmitSignal(SignalName.KnownCommand, $"Attempted to delete the \"{groupName}\" user group, but there was no root /users/ directory.");
-                return;
-            }
-
-            var groupDirectory = rootUserGroupsDirectory.FindDirectory(groupName);
-            if (groupDirectory == null)
-            {
-                EmitSignal(SignalName.KnownCommand, $"Attempted to delete the \"{groupName}\" user group, but it does not exist.");
-                return;
-            }
-
-            rootUserGroupsDirectory.Entities.Remove(groupDirectory);
-            EmitSignal(SignalName.KnownCommand, $"\"{groupName}\" user group removed.");
-        }
-
-        private void AddUserToGroup(IEnumerable<string> arguments)
-        {
-            if(arguments.Count() != 2)
-            {
-                EmitSignal(SignalName.KnownCommand, $"\"addusertogroup\" takes 2 arguments, use \"help addusertogroup\" to see an example.");
-                return;
-            }
-
-            var userName = arguments.FirstOrDefault();
-            if (string.IsNullOrEmpty(userName))
-            {
-                GD.Print($"Attempted to add a user to a group, but user name was not provided.");
-                return;
-            }
-
-            var groupName = arguments.LastOrDefault();
-            if (string.IsNullOrEmpty(groupName))
-            {
-                GD.Print($"Attempted to add a user to a group, but user group was not provided.");
-                return;
-            }
-
-            var rootUserGroupsDirectory = _directoryService.GetRootDirectory().FindDirectory("users/groups");
-            if (rootUserGroupsDirectory == null)
-            {
-                EmitSignal(SignalName.KnownCommand, $"Attempted to add the \"{userName}\" user to the \"{groupName}\" user group, but there was no root /users/ directory.");
-                return;
-            }
-
-            var groupDirectory = rootUserGroupsDirectory.FindDirectory(groupName);
-            if (groupDirectory == null)
-            {
-                EmitSignal(SignalName.KnownCommand, $"\"{groupName}\" user group does not exist.");
-                return;
-            }
-
-            var userFileInGroup = groupDirectory.FindFile(userName);
-            if (userFileInGroup != null)
-            {
-                EmitSignal(SignalName.KnownCommand, $"\"{userName}\" is already a part of the \"{groupName}\" user group.");
-                return;
-            }
-
-            DirectoryFile userGroupFile = new()
-            {
-                Name = userName,
-                ParentId = groupDirectory.Id,
-                Permissions = new() { Permission.AdminRead, Permission.AdminWrite, Permission.UserRead, Permission.UserWrite }
-            };
-            groupDirectory.Entities.Add(userGroupFile);
-            EmitSignal(SignalName.KnownCommand, $"\"{userName}\" added to the \"{groupName}\" user group.");
-        }
-
-        private void DeleteUserFromGroup(IEnumerable<string> arguments)
-        {
-            if (arguments.Count() != 2)
-            {
-                EmitSignal(SignalName.KnownCommand, $"\"deleteuserfromgroup\" takes 2 arguments, use \"help deleteuserfromgroup\" to see an example.");
-                return;
-            }
-
-            var userName = arguments.FirstOrDefault();
-            if (string.IsNullOrEmpty(userName))
-            {
-                GD.Print($"Attempted to remove a user from a group, but user name was not provided.");
-                return;
-            }
-
-            var groupName = arguments.LastOrDefault();
-            if (string.IsNullOrEmpty(groupName))
-            {
-                GD.Print($"Attempted to remove a user from a group, but user group was not provided.");
-                return;
-            }
-
-            var rootUserGroupsDirectory = _directoryService.GetRootDirectory().FindDirectory("users/groups");
-            if (rootUserGroupsDirectory == null)
-            {
-                EmitSignal(SignalName.KnownCommand, $"Attempted to remove the \"{userName}\" user from the \"{groupName}\" user group, but there was no root /users/ directory.");
-                return;
-            }
-
-            var groupDirectory = rootUserGroupsDirectory.FindDirectory(groupName);
-            if (groupDirectory == null)
-            {
-                EmitSignal(SignalName.KnownCommand, $"\"{groupName}\" user group does not exist.");
-                return;
-            }
-
-            var userFileInGroup = groupDirectory.FindFile(userName);
-            if (userFileInGroup == null)
-            {
-                EmitSignal(SignalName.KnownCommand, $"\"{userName}\" is not part of the \"{groupName}\" user group.");
-                return;
-            }
-
-            groupDirectory.Entities.Remove(userFileInGroup);
-            EmitSignal(SignalName.KnownCommand, $"\"{userName}\" removed from the \"{groupName}\" user group.");
-        }
-
-        private void ViewUserGroup(string groupName)
-        {
-            if (string.IsNullOrEmpty(groupName))
-            {
-                GD.Print($"Attempted to view a user group, but user group name was not provided.");
-                return;
-            }
-
-            var rootUserGroupsDirectory = _directoryService.GetRootDirectory().FindDirectory("users/groups");
-            if (rootUserGroupsDirectory == null)
-            {
-                EmitSignal(SignalName.KnownCommand, $"Attempted to view the \"{groupName}\" user group, but there was no root /users/ directory.");
-                return;
-            }
-
-            var groupDirectory = rootUserGroupsDirectory.FindDirectory(groupName);
-            if (groupDirectory == null)
-            {
-                EmitSignal(SignalName.KnownCommand, $"\"{groupName}\" user group does not exist.");
-                return;
-            }
-
-            var usersInGroup = groupDirectory.Entities.Where(entity => !entity.IsDirectory);
-            if (!usersInGroup.Any())
-            {
-                EmitSignal(SignalName.KnownCommand, $"No users in the \"{groupName}\" user group.");
-                return;
-            }
-
-            EmitSignal(SignalName.KnownCommand, string.Join('\n', $"{groupName} users", "═".Repeat($"{groupName} users".Length), string.Join(", ", usersInGroup)));
         }
     }
 }

--- a/Services/UserService.cs
+++ b/Services/UserService.cs
@@ -1,0 +1,298 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Godot;
+
+using Terminal.Constants;
+using Terminal.Enums;
+using Terminal.Extensions;
+using Terminal.Models;
+
+namespace Terminal.Services
+{
+    /// <summary>
+    /// A global singleton that is responsible for managing users.
+    /// </summary>
+    public partial class UserService : Node
+    {
+        private DirectoryService _directoryService;
+
+        public override void _Ready()
+        {
+            _directoryService = GetNode<DirectoryService>(ServicePathConstants.DirectoryServicePath);
+        }
+
+        /// <summary>
+        /// Makes a user in the <c>/users/</c> folder.
+        /// </summary>
+        /// <param name="arguments">
+        /// A collection of arguments that should contain the new user name.
+        /// </param>
+        /// <returns>
+        /// A <see langword="string"/> containing the status of the user creation.
+        /// </returns>
+        public string MakeUser(IEnumerable<string> arguments)
+        {
+            var userActionInvalidMessage = GetActionIsInvalidMessage(false, arguments, "user", "users");
+            if (!string.IsNullOrEmpty(userActionInvalidMessage))
+            {
+                return userActionInvalidMessage;
+            }
+
+            var userName = arguments.FirstOrDefault();
+            var rootUsersDirectory = _directoryService.GetRootDirectory().FindDirectory("users");
+
+            rootUsersDirectory.Entities.Add(DirectoryConstants.GetDefaultUserDirectory(rootUsersDirectory, userName));
+            return $"\"{userName}\" user created.";
+        }
+
+        /// <summary>
+        /// Deletes a user from the <c>/users/</c> folder.
+        /// </summary>
+        /// <param name="arguments">
+        /// A collection of arguments that should contain the user name.
+        /// </param>
+        /// <returns>
+        /// A <see langword="string"/> containing the status of the user deletion.
+        /// </returns>
+        public string DeleteUser(IEnumerable<string> arguments)
+        {
+            var userActionInvalidMessage = GetActionIsInvalidMessage(true, arguments, "user", "users");
+            if (!string.IsNullOrEmpty(userActionInvalidMessage))
+            {
+                return userActionInvalidMessage;
+            }
+
+            var userName = arguments.FirstOrDefault();
+            var rootUsersDirectory = _directoryService.GetRootDirectory().FindDirectory("users");
+            var userDirectoryToDelete = rootUsersDirectory.FindDirectory(userName);
+
+            rootUsersDirectory.Entities.Remove(userDirectoryToDelete);
+            return $"\"{userName}\" user removed.";
+        }
+
+        /// <summary>
+        /// Creates a user group in the <c>/users/groups/</c> folder.
+        /// </summary>
+        /// <param name="arguments">
+        /// A collection of arguments that should contain the new user group name.
+        /// </param>
+        /// <returns>
+        /// A <see langword="string"/> containing the status of the user group creation.
+        /// </returns>
+        public string MakeGroup(IEnumerable<string> arguments)
+        {
+            var groupActionInvalidMessage = GetActionIsInvalidMessage(false, arguments, "user group", "users/groups");
+            if (!string.IsNullOrEmpty(groupActionInvalidMessage))
+            {
+                return groupActionInvalidMessage;
+            }
+
+            var groupName = arguments.FirstOrDefault();
+            var rootUserGroupsDirectory = _directoryService.GetRootDirectory().FindDirectory("users/groups");
+
+            rootUserGroupsDirectory.Entities.Add(new DirectoryFolder()
+            {
+                Name = groupName,
+                ParentId = rootUserGroupsDirectory.Id,
+                Permissions = new() { Permission.AdminRead, Permission.AdminWrite, Permission.UserRead, Permission.UserWrite }
+            });
+            return $"\"{groupName}\" user group created.";
+        }
+
+        /// <summary>
+        /// Deletes a user group from the <c>/users/groups/</c> folder.
+        /// </summary>
+        /// <param name="arguments">
+        /// A collection of arguments that should contain the user group name.
+        /// </param>
+        /// <returns>
+        /// A <see langword="string"/> containing the status of the user group deletion.
+        /// </returns>
+        public string DeleteGroup(IEnumerable<string> arguments)
+        {
+            var groupActionInvalidMessage = GetActionIsInvalidMessage(true, arguments, "user group", "users/groups");
+            if (!string.IsNullOrEmpty(groupActionInvalidMessage))
+            {
+                return groupActionInvalidMessage;
+            }
+
+            var groupName = arguments.FirstOrDefault();
+            var rootUserGroupsDirectory = _directoryService.GetRootDirectory().FindDirectory($"users/groups");
+            var groupDirectory = rootUserGroupsDirectory.FindDirectory(groupName);
+
+            rootUserGroupsDirectory.Entities.Remove(groupDirectory);
+            return $"\"{groupName}\" user group removed.";
+        }
+
+        /// <summary>
+        /// Adds a user to a user group in the <c>/users/groups/</c> folder.
+        /// </summary>
+        /// <param name="arguments">
+        /// A collection of arguments that should contain the user and user group name.
+        /// </param>
+        /// <returns>
+        /// A <see langword="string"/> containing the status of the user group addition.
+        /// </returns>
+        public string AddUserToGroup(IEnumerable<string> arguments)
+        {
+            var groupActionInvalidMessage = GetGroupActionIsInvalidMessage(false, arguments);
+            if (!string.IsNullOrEmpty(groupActionInvalidMessage))
+            {
+                return groupActionInvalidMessage;
+            }
+
+            var userName = arguments.FirstOrDefault();
+            var groupName = arguments.LastOrDefault();
+            var rootUserGroupsDirectory = _directoryService.GetRootDirectory().FindDirectory($"users/groups/{groupName}");
+            var groupDirectory = rootUserGroupsDirectory.FindDirectory(groupName);
+
+            DirectoryFile userGroupFile = new()
+            {
+                Name = userName,
+                ParentId = groupDirectory.Id,
+                Permissions = new() { Permission.AdminRead, Permission.AdminWrite, Permission.UserRead, Permission.UserWrite }
+            };
+            groupDirectory.Entities.Add(userGroupFile);
+            return $"\"{userName}\" added to the \"{groupName}\" user group.";
+        }
+
+        /// <summary>
+        /// Deletes a user from a user group in the <c>/users/groups/</c> folder.
+        /// </summary>
+        /// <param name="arguments">
+        /// A collection of arguments that should contain the user and user group name.
+        /// </param>
+        /// <returns>
+        /// A <see langword="string"/> containing the status of the user group removal.
+        /// </returns>
+        public string DeleteUserFromGroup(IEnumerable<string> arguments)
+        {
+            var groupActionInvalidMessage = GetGroupActionIsInvalidMessage(true, arguments);
+            if (!string.IsNullOrEmpty(groupActionInvalidMessage))
+            {
+                return groupActionInvalidMessage;
+            }
+
+            var userName = arguments.FirstOrDefault();
+            var groupName = arguments.LastOrDefault();
+            var rootUserGroupsDirectory = _directoryService.GetRootDirectory().FindDirectory($"users/groups/{groupName}");
+            var groupDirectory = rootUserGroupsDirectory.FindDirectory(groupName);
+
+            var userFileInGroup = groupDirectory.FindFile(userName);
+            groupDirectory.Entities.Remove(userFileInGroup);
+            return $"\"{userName}\" removed from the \"{groupName}\" user group.";
+        }
+
+        /// <summary>
+        /// Returns a list of all users in the <paramref name="groupName"/> user group.
+        /// </summary>
+        /// <param name="groupName">
+        /// The name of the user group to get the users for.
+        /// </param>
+        /// <returns>
+        /// A list of users from the provided <paramref name="groupName"/> user group.
+        /// </returns>
+        public string ViewUserGroup(string groupName)
+        {
+            if (string.IsNullOrEmpty(groupName))
+            {
+                return "Attempted to view a user group, but user group name was not provided.";
+            }
+
+            var rootUserGroupsDirectory = _directoryService.GetRootDirectory().FindDirectory("users/groups");
+            if (rootUserGroupsDirectory == null)
+            {
+                return $"Attempted to view the \"{groupName}\" user group, but there was no root /users/ directory.";
+            }
+
+            var groupDirectory = rootUserGroupsDirectory.FindDirectory(groupName);
+            if (groupDirectory == null)
+            {
+                return $"\"{groupName}\" user group does not exist.";
+            }
+
+            var usersInGroup = groupDirectory.Entities.Where(entity => !entity.IsDirectory);
+            if (!usersInGroup.Any())
+            {
+                return $"No users in the \"{groupName}\" user group.";
+            }
+
+            return string.Join('\n', $"{groupName} users", "═".Repeat($"{groupName} users".Length), string.Join(", ", usersInGroup));
+        }
+
+        private string GetActionIsInvalidMessage(bool forRemoval, IEnumerable<string> arguments, string targetEntity, string parentFolderPath)
+        {
+            var action = forRemoval ? "remove" : "make";
+            var entityName = arguments.FirstOrDefault();
+            if (string.IsNullOrEmpty(entityName))
+            {
+                return $"Attempted to {action} a {targetEntity}, but {targetEntity} name was not provided.";
+            }
+
+            var rootEntityDirectory = _directoryService.GetRootDirectory().FindDirectory(parentFolderPath);
+            if (rootEntityDirectory == null)
+            {
+                return $"Attempted to {action} the \"{entityName}\" {targetEntity}, but there was no {parentFolderPath} directory.";
+            }
+
+            var entityDirectory = rootEntityDirectory.FindDirectory(entityName);
+            if (forRemoval && entityDirectory == null)
+            {
+                return $"Attempted to {action} the \"{entityName}\" {targetEntity}, but it does not exist.";
+            }
+            if (!forRemoval && entityDirectory != null)
+            {
+                return $"Attempted to {action} the new {targetEntity} \"{entityName}\", but it already existed.";
+            }
+
+            return string.Empty;
+        }
+
+        private string GetGroupActionIsInvalidMessage(bool forRemoval, IEnumerable<string> arguments)
+        {
+            var command = forRemoval ? "removeuserfromgroup" : "addusertogroup";
+            if (arguments.Count() != 2)
+            {
+                return $"\"{command}\" takes 2 arguments, use \"help {command}\" to see an example.";
+            }
+
+            var action = forRemoval ? "remove" : "make";
+            var actionVerb = forRemoval ? "from" : "to";
+            var userName = arguments.FirstOrDefault();
+            if (string.IsNullOrEmpty(userName))
+            {
+                return $"Attempted to {action} a user {actionVerb} a user group, but user name was not provided.";
+            }
+
+            var groupName = arguments.LastOrDefault();
+            if (string.IsNullOrEmpty(groupName))
+            {
+                return $"Attempted to {action} a user {actionVerb} a user group, but user group name was not provided.";
+            }
+
+            var rootUserGroupsDirectory = _directoryService.GetRootDirectory().FindDirectory("users/groups");
+            if (rootUserGroupsDirectory == null)
+            {
+                return $"Attempted to {action} the \"{userName}\" user {actionVerb} the \"{groupName}\" user group, but there was no /users/groups/ directory.";
+            }
+
+            var groupDirectory = rootUserGroupsDirectory.FindDirectory(groupName);
+            if (groupDirectory == null)
+            {
+                return $"\"{groupName}\" user group does not exist.";
+            }
+
+            var userFileInGroup = groupDirectory.FindFile(userName);
+            if (forRemoval && userFileInGroup == null)
+            {
+                return $"\"{userName}\" is not part of the \"{groupName}\" user group.";
+            }
+            if (!forRemoval && userFileInGroup != null)
+            {
+                return $"\"{userName}\" is already a part of the \"{groupName}\" user group.";
+            }
+
+            return string.Empty;
+        }
+    }
+}

--- a/project.godot
+++ b/project.godot
@@ -26,6 +26,7 @@ PersistService="*res://Services/PersistService.cs"
 ScreenNavigator="*res://Navigators/ScreenNavigator.cs"
 AutoCompleteService="*res://Services/AutoCompleteService.cs"
 NetworkService="*res://Services/NetworkService.cs"
+UserService="*res://Services/UserService.cs"
 
 [display]
 

--- a/project.godot
+++ b/project.godot
@@ -27,6 +27,7 @@ ScreenNavigator="*res://Navigators/ScreenNavigator.cs"
 AutoCompleteService="*res://Services/AutoCompleteService.cs"
 NetworkService="*res://Services/NetworkService.cs"
 UserService="*res://Services/UserService.cs"
+PermissionsService="*res://Services/PermissionsService.cs"
 
 [display]
 


### PR DESCRIPTION
This PR will reduce the responsibility and length of the `UserInput` and `ScrollableContainer` files, which were both over 500 lines (`UserInput` was almost 1,000 lines).

There should be services to abstract the units of work for the commands given by the user where appropriate.

This PR also cleans up unneeded `delegate` methods defined in `UserInput` that were needlessly subscribed to in `ScrollableContainer`.