### PR TITLE
Enable MacOS export VRAM compression setting

### DIFF
--- a/Constants/DirectoryConstants.cs
+++ b/Constants/DirectoryConstants.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Terminal.Enums;
 using Terminal.Factories;
 using Terminal.Models;

--- a/Inputs/UserInput.cs
+++ b/Inputs/UserInput.cs
@@ -7,7 +7,6 @@ using Terminal.Audio;
 using Terminal.Constants;
 using Terminal.Enums;
 using Terminal.Extensions;
-using Terminal.Models;
 using Terminal.Services;
 
 namespace Terminal.Inputs

--- a/Models/FileSystem.cs
+++ b/Models/FileSystem.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
-using Terminal.Constants;
+
 using Terminal.Extensions;
 
 namespace Terminal.Models

--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@ terminal_os is a terminal game written in the Godot engine using .NET 8 and C#.
 
 ![image](https://github.com/user-attachments/assets/4d4f92c8-3938-4590-8a6f-7b5dafccfe3b)
 
+## Supported Platforms
+| |Windows|MacOS|Linux|Web|Android|iOS|
+|-:|:-:|:-:|:-:|:-:|:-:|:-:|
+|Supported|&check;|&check;|&check;|&cross;|&cross;|&cross;|
+|Planned|-|-|-|&check;|&check;|&check;|
+
 ## Features
 ### Informational Commands
 - View all the commands for terminal_os using the `commands` command
@@ -43,7 +49,7 @@ terminal_os is a terminal game written in the Godot engine using .NET 8 and C#.
 - Delete a user with the `deleteuser` command
 - View a user group with the `viewgroup` command
 - Make a user group with the `makegroup` command
-- Delete a user gropu with the `deletegroup` command
+- Delete a user group with the `deletegroup` command
 - Add a user to a group with the `addusertogroup` command
 - Delete a user from a group with the `deleteuserfromgroup` command
 

--- a/Services/AutoCompleteService.cs
+++ b/Services/AutoCompleteService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System;
 using Godot;
@@ -5,7 +6,6 @@ using Godot;
 using Terminal.Enums;
 using Terminal.Models;
 using Terminal.Constants;
-using System.Collections.Generic;
 
 namespace Terminal.Services
 {

--- a/project.godot
+++ b/project.godot
@@ -36,3 +36,7 @@ window/size/mode=3
 [dotnet]
 
 project/assembly_name="Terminal"
+
+[rendering]
+
+textures/vram_compression/import_etc2_astc=true


### PR DESCRIPTION
This PR will make it possible to export terminal_os to MacOS.

It will also clean up some `using` statements in the code, and update the README with supported platforms.