### PR TITLE
Add display.conf file for adjusting monitor shader and adjusting font size

### DIFF
--- a/Constants/ConfigConstants.cs
+++ b/Constants/ConfigConstants.cs
@@ -1,9 +1,9 @@
 ﻿namespace Terminal.Constants
 {
     /// <summary>
-    /// A <see langword="static"/> collection of constants that contain values relevant to config files.
+    /// A <see langword="static"/> collection of constants that contain values relevant to config files and their keys.
     /// </summary>
-    public static class ConfigFileConstants
+    public static class ConfigConstants
     {
         /// <summary>
         /// The extension for config files.
@@ -39,5 +39,20 @@
         /// The full name of the display config file.
         /// </summary>
         public const string DisplayConfigFileName = $"{DisplayConfigName}.{ConfigFileExtension}";
+
+        /// <summary>
+        /// The key for volume configuration.
+        /// </summary>
+        public const string VolumeConfigKey = "volume";
+
+        /// <summary>
+        /// The key for monitor shader intensity configuration.
+        /// </summary>
+        public const string MonitorShaderIntensityConfigKey = "monitor-effect-intensity";
+
+        /// <summary>
+        /// The key for font size configuration.
+        /// </summary>
+        public const string FontSizeConfigKey = "font-size";
     }
 }

--- a/Constants/ConfigFileConstants.cs
+++ b/Constants/ConfigFileConstants.cs
@@ -1,0 +1,43 @@
+﻿namespace Terminal.Constants
+{
+    /// <summary>
+    /// A <see langword="static"/> collection of constants that contain values relevant to config files.
+    /// </summary>
+    public static class ConfigFileConstants
+    {
+        /// <summary>
+        /// The extension for config files.
+        /// </summary>
+        public const string ConfigFileExtension = "conf";
+
+        /// <summary>
+        /// The name of the color config file, without an extension.
+        /// </summary>
+        public const string ColorConfigName = "color";
+
+        /// <summary>
+        /// The name of the user config file, without an extension.
+        /// </summary>
+        public const string UserConfigName = "user";
+
+        /// <summary>
+        /// The name of the display config file, without an extension.
+        /// </summary>
+        public const string DisplayConfigName = "display";
+
+        /// <summary>
+        /// The full name of the color config file.
+        /// </summary>
+        public const string ColorConfigFileName = $"{ColorConfigName}.{ConfigFileExtension}";
+
+        /// <summary>
+        /// The full name of the user config file.
+        /// </summary>
+        public const string UserConfigFileName = $"{UserConfigName}.{ConfigFileExtension}";
+
+        /// <summary>
+        /// The full name of the display config file.
+        /// </summary>
+        public const string DisplayConfigFileName = $"{DisplayConfigName}.{ConfigFileExtension}";
+    }
+}

--- a/Constants/DirectoryConstants.cs
+++ b/Constants/DirectoryConstants.cs
@@ -242,8 +242,8 @@ namespace Terminal.Constants
             {
                 new DirectoryFile()
                 {
-                    Name = ConfigFileConstants.ColorConfigName,
-                    Extension = ConfigFileConstants.ConfigFileExtension,
+                    Name = ConfigConstants.ColorConfigName,
+                    Extension = ConfigConstants.ConfigFileExtension,
                     Contents = "green:377a1c\nblue:1c387a\nteal:1c677a\npurple:5e1c7a\norange:7a2f1c\nred:7a1c38",
                     ParentId = systemConfigDirectory.Id,
                     Permissions = _userReadWritePermissions
@@ -332,17 +332,17 @@ namespace Terminal.Constants
             {
                 new DirectoryFile()
                 {
-                    Name = ConfigFileConstants.UserConfigName,
-                    Extension = ConfigFileConstants.ConfigFileExtension,
-                    Contents = "volume:100",
+                    Name = ConfigConstants.UserConfigName,
+                    Extension = ConfigConstants.ConfigFileExtension,
+                    Contents = $"{ConfigConstants.VolumeConfigKey}:100",
                     ParentId = configDirectory.Id,
                     Permissions = _userReadWritePermissions
                 },
                 new DirectoryFile()
                 {
-                    Name = ConfigFileConstants.DisplayConfigName,
-                    Extension = ConfigFileConstants.ConfigFileExtension,
-                    Contents = "effect:100",
+                    Name = ConfigConstants.DisplayConfigName,
+                    Extension = ConfigConstants.ConfigFileExtension,
+                    Contents = $"{ConfigConstants.MonitorShaderIntensityConfigKey}:100\n{ConfigConstants.FontSizeConfigKey}:36",
                     ParentId = configDirectory.Id,
                     Permissions = _userReadWritePermissions
                 }

--- a/Constants/DirectoryConstants.cs
+++ b/Constants/DirectoryConstants.cs
@@ -8,6 +8,9 @@ using Terminal.Models;
 
 namespace Terminal.Constants
 {
+    /// <summary>
+    /// A <see langword="static"/> collection of constant values and methods for managing or creating directories.
+    /// </summary>
     public static class DirectoryConstants
     {
         /// <summary>
@@ -239,8 +242,8 @@ namespace Terminal.Constants
             {
                 new DirectoryFile()
                 {
-                    Name = "color",
-                    Extension = "conf",
+                    Name = ConfigFileConstants.ColorConfigName,
+                    Extension = ConfigFileConstants.ConfigFileExtension,
                     Contents = "green:377a1c\nblue:1c387a\nteal:1c677a\npurple:5e1c7a\norange:7a2f1c\nred:7a1c38",
                     ParentId = systemConfigDirectory.Id,
                     Permissions = _userReadWritePermissions
@@ -329,9 +332,17 @@ namespace Terminal.Constants
             {
                 new DirectoryFile()
                 {
-                    Name = "user",
-                    Extension = "conf",
+                    Name = ConfigFileConstants.UserConfigName,
+                    Extension = ConfigFileConstants.ConfigFileExtension,
                     Contents = "volume:100",
+                    ParentId = configDirectory.Id,
+                    Permissions = _userReadWritePermissions
+                },
+                new DirectoryFile()
+                {
+                    Name = ConfigFileConstants.DisplayConfigName,
+                    Extension = ConfigFileConstants.ConfigFileExtension,
+                    Contents = "effect:100",
                     ParentId = configDirectory.Id,
                     Permissions = _userReadWritePermissions
                 }

--- a/Constants/ShaderConstants.cs
+++ b/Constants/ShaderConstants.cs
@@ -1,0 +1,70 @@
+﻿using System.Collections.Generic;
+
+using Terminal.Models;
+using Terminal.Shaders;
+
+namespace Terminal.Constants
+{
+    /// <summary>
+    /// A <see langword="static"/> collection of values relevant to the <see cref="Monitor"/> shader.
+    /// </summary>
+    public static class ShaderConstants
+    {
+        /// <summary>
+        /// A collection of <see cref="ShaderParameter"/> used by the <see cref="Monitor"/> shader.
+        /// </summary>
+        public static readonly List<ShaderParameter> ShaderParameters = new()
+        {
+            new()
+            {
+                Name = "grille_opacity",
+                MaxValue = 0.088
+            },
+            new()
+            {
+                Name = "roll_speed",
+                MaxValue = 3.0
+            },
+            new()
+            {
+                Name = "scanlines_opacity",
+                MaxValue = 0.2
+            },
+            new()
+            {
+                Name = "noise_opacity",
+                MaxValue = 0.084
+            },
+            new()
+            {
+                Name = "static_noise_intensity",
+                MaxValue = 0.02
+            },
+            new()
+            {
+                Name = "static_noise_intensity",
+                MaxValue = 0.02
+            },
+            new()
+            {
+                Name = "static_noise_intensity",
+                MaxValue = 0.02
+            },
+            new()
+            {
+                Name = "vignette_intensity",
+                MaxValue = 0.2
+            },
+            new()
+            {
+                Name = "vignette_opacity",
+                MaxValue = 0.4
+            },
+            new()
+            {
+                Name = "distort_intensity",
+                MaxValue = 0.018
+            }
+        };
+    }
+}

--- a/Constants/ShaderConstants.cs
+++ b/Constants/ShaderConstants.cs
@@ -22,11 +22,6 @@ namespace Terminal.Constants
             },
             new()
             {
-                Name = "roll_speed",
-                MaxValue = 3.0
-            },
-            new()
-            {
                 Name = "scanlines_opacity",
                 MaxValue = 0.2
             },
@@ -34,6 +29,11 @@ namespace Terminal.Constants
             {
                 Name = "noise_opacity",
                 MaxValue = 0.084
+            },
+            new()
+            {
+                Name = "vignette_opacity",
+                MaxValue = 0.4
             },
             new()
             {
@@ -54,11 +54,6 @@ namespace Terminal.Constants
             {
                 Name = "vignette_intensity",
                 MaxValue = 0.2
-            },
-            new()
-            {
-                Name = "vignette_opacity",
-                MaxValue = 0.4
             },
             new()
             {

--- a/Containers/ScrollableContainer.cs
+++ b/Containers/ScrollableContainer.cs
@@ -19,6 +19,7 @@ namespace Terminal.Containers
     {
         private UserInput _userInput;
         private Theme _defaultUserInputTheme;
+        private ConfigService _configService;
         private DirectoryService _directoryService;
         private PersistService _persistService;
         private NetworkService _networkService;
@@ -28,6 +29,7 @@ namespace Terminal.Containers
         public override void _Ready()
         {
             _directoryService = GetNode<DirectoryService>(ServicePathConstants.DirectoryServicePath);
+            _configService = GetNode<ConfigService>(ServicePathConstants.ConfigServicePath);
             _persistService = GetNode<PersistService>(ServicePathConstants.PersistServicePath);
             _networkService = GetNode<NetworkService>(ServicePathConstants.NetworkServicePath);
             _defaultUserInputTheme = GD.Load<Theme>(ThemePathConstants.MonospaceFontThemePath);
@@ -35,6 +37,9 @@ namespace Terminal.Containers
             _fileInput = GetNode<FileInput>("%FileInput");
             _fileInput.SaveFileCommand += SaveFileCommandResponse;
             _fileInput.CloseFileCommand += CloseFileCommandResponse;
+
+            UpdateThemeFontSize(_configService.FontSize);
+            _configService.OnFontSizeConfigChange += UpdateThemeFontSize;
 
             AddNewUserInput();
         }
@@ -56,6 +61,8 @@ namespace Terminal.Containers
                 }
             }
         }
+
+        private void UpdateThemeFontSize(int fontSize) => _defaultUserInputTheme.DefaultFontSize = fontSize;
 
         private void AddNewUserInput()
         {

--- a/Extensions/ConfigFileExtensions.cs
+++ b/Extensions/ConfigFileExtensions.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Godot;
+
+namespace Terminal.Extensions
+{
+    /// <summary>
+    /// A <see langword="static"/> collection of extension methods for managing config files.
+    /// </summary>
+    public static class ConfigFileExtensions
+    {
+        /// <summary>
+        /// Gets an integer config value from a config file.
+        /// </summary>
+        /// <param name="targetConfig">
+        /// A <see cref="Dictionary{TKey, TValue}"/> filled with <see langword="string"/> keys and values, which represents a config file's contents.
+        /// </param>
+        /// <param name="defaultValue">
+        /// A default value to return when unable to parse the config file.
+        /// </param>
+        /// <param name="configFileName">
+        /// The name of the config file, used for logging.
+        /// </param>
+        /// <returns>
+        /// An <see langword="int"/> value from the <paramref name="targetConfig"/>.
+        /// </returns>
+        public static int GetLatestIntegerConfig(this Dictionary<string, string> targetConfig, int defaultValue, string configFileName)
+        {
+            if (targetConfig == null)
+            {
+                GD.Print($"Attempted to parse integer-based config data, but \"{configFileName}\" file was not found.");
+                return defaultValue;
+            }
+
+            var configKeyValue = targetConfig.FirstOrDefault(config =>
+            {
+                if (!int.TryParse(config.Value, out int configValue))
+                {
+                    GD.Print($"Attempted to parse integer-based config data from {configFileName}, but {config.Value} isn't a valid number.");
+                    return false;
+                }
+
+                return true;
+            });
+
+            if (configKeyValue.Key == default || configKeyValue.Value == default)
+            {
+                return defaultValue;
+            }
+
+            return int.Parse(configKeyValue.Value);
+        }
+    }
+}

--- a/Extensions/ConfigFileExtensions.cs
+++ b/Extensions/ConfigFileExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Godot;
 
@@ -10,21 +11,36 @@ namespace Terminal.Extensions
     public static class ConfigFileExtensions
     {
         /// <summary>
-        /// Gets an integer config value from a config file.
+        /// Gets a clamped integer config value associated with the provided <paramref name="configKey"/> from the <paramref name="configFileName"/> config file.
+        /// <para>
+        /// The minimum value will be <paramref name="minValue"/>, and the maximum value will be <paramref name="defaultValue"/>.
+        /// </para>
         /// </summary>
         /// <param name="targetConfig">
         /// A <see cref="Dictionary{TKey, TValue}"/> filled with <see langword="string"/> keys and values, which represents a config file's contents.
         /// </param>
-        /// <param name="defaultValue">
-        /// A default value to return when unable to parse the config file.
+        /// <param name="configKey">
+        /// The key of the desired config from the config file.
         /// </param>
         /// <param name="configFileName">
         /// The name of the config file, used for logging.
         /// </param>
+        /// <param name="defaultValue">
+        /// A default value to return when unable to parse the config file. Also used as the maximum value for clamping the config value.
+        /// <para>
+        /// Defaults to <c>100</c>.
+        /// </para>
+        /// </param>
+        /// <param name="minValue">
+        /// The minimum value for clamping the config value.
+        /// <para>
+        /// Defaults to <c>0</c>.
+        /// </para>
+        /// </param>
         /// <returns>
-        /// An <see langword="int"/> value from the <paramref name="targetConfig"/>.
+        /// An <see langword="int"/> value from the <paramref name="targetConfig"/>, clamped between <paramref name="minValue"/> and <paramref name="defaultValue"/>.
         /// </returns>
-        public static int GetLatestIntegerConfig(this Dictionary<string, string> targetConfig, int defaultValue, string configFileName)
+        public static int GetLatestIntegerConfig(this Dictionary<string, string> targetConfig, string configKey, string configFileName, int defaultValue = 100, int minValue = 0)
         {
             if (targetConfig == null)
             {
@@ -32,23 +48,26 @@ namespace Terminal.Extensions
                 return defaultValue;
             }
 
-            var configKeyValue = targetConfig.FirstOrDefault(config =>
-            {
-                if (!int.TryParse(config.Value, out int configValue))
+            var configKeyValue = targetConfig
+                .Where(config => config.Key.Equals(configKey, StringComparison.OrdinalIgnoreCase))
+                .FirstOrDefault(config =>
                 {
-                    GD.Print($"Attempted to parse integer-based config data from {configFileName}, but {config.Value} isn't a valid number.");
-                    return false;
-                }
+                    if (!int.TryParse(config.Value, out int configValue))
+                    {
+                        GD.Print($"Attempted to parse integer-based config data from {configFileName}, but {config.Value} isn't a valid number.");
+                        return false;
+                    }
 
-                return true;
-            });
+                    return true;
+                });
 
             if (configKeyValue.Key == default || configKeyValue.Value == default)
             {
+                GD.Print($"Parsed integer-based config data from {configFileName}, but the key or value was a default value.");
                 return defaultValue;
             }
 
-            return int.Parse(configKeyValue.Value);
+            return Math.Clamp(int.Parse(configKeyValue.Value), minValue, defaultValue);
         }
     }
 }

--- a/Extensions/NumberExtensions.cs
+++ b/Extensions/NumberExtensions.cs
@@ -32,5 +32,33 @@
             double scale = (double)(newEnd - newStart) / (originalEnd - originalStart);
             return (int)(newStart + ((valueToConvert - originalStart) * scale));
         }
+
+        /// <summary>
+        /// Converts the <paramref name="valueToConvert"/> from the original range (<paramref name="originalStart"/> - <paramref name="originalEnd"/>)
+        /// to the new range (<paramref name="newStart"/> - <paramref name="newEnd"/>).
+        /// </summary>
+        /// <param name="valueToConvert">
+        /// The value to convert.
+        /// </param>
+        /// <param name="originalStart">
+        /// The start of the original range.
+        /// </param>
+        /// <param name="originalEnd">
+        /// The end of the original range.
+        /// </param>
+        /// <param name="newStart">
+        /// The start of the new range.
+        /// </param>
+        /// <param name="newEnd">
+        /// The end of the new range.
+        /// </param>
+        /// <returns>
+        /// The <paramref name="valueToConvert"/> converted to be within the new range (<paramref name="newStart"/> - <paramref name="newEnd"/>).
+        /// </returns>
+        public static double ConvertRange(this int valueToConvert, int originalStart, int originalEnd, double newStart, double newEnd)
+        {
+            double scale = (newEnd - newStart) / (originalEnd - originalStart);
+            return newStart + ((valueToConvert - originalStart) * scale);
+        }
     }
 }

--- a/Inputs/FileInput.cs
+++ b/Inputs/FileInput.cs
@@ -38,7 +38,6 @@ namespace Terminal.Inputs
 
         private PersistService _persistService;
         private ConfigService _configService;
-        private Theme _defaultUserInputTheme;
         private ScrollableContainer _scrollableContainer;
         private VBoxContainer _fileEditorContainer;
         private RichTextLabel _saveLabel;
@@ -50,7 +49,6 @@ namespace Terminal.Inputs
         {
             _persistService = GetNode<PersistService>(ServicePathConstants.PersistServicePath);
             _configService = GetNode<ConfigService>(ServicePathConstants.ConfigServicePath);
-            _defaultUserInputTheme = GD.Load<Theme>(ThemePathConstants.MonospaceFontThemePath);
             _scrollableContainer = GetNode<ScrollableContainer>("%ScrollableContainer");
             _fileEditorContainer = GetParent<VBoxContainer>();
             _saveLabel = GetNode<RichTextLabel>("%SaveLabel");

--- a/Inputs/UserInput.cs
+++ b/Inputs/UserInput.cs
@@ -200,7 +200,7 @@ namespace Terminal.Inputs
             if(command == UserCommand.EditFile && inputWithoutDirectory.Split(' ').Length > 1)
             {
                 ReleaseFocus();
-                UnsubscribeFromEvents();
+                UnsubscribeAndStopInput();
             }
         }
 

--- a/Models/ShaderParameter.cs
+++ b/Models/ShaderParameter.cs
@@ -1,0 +1,33 @@
+﻿using Godot;
+
+namespace Terminal.Models
+{
+    /// <summary>
+    /// Represents a "uniform" (exposed) variable for a shader from the shader code.
+    /// </summary>
+    public class ShaderParameter
+    {
+        /// <summary>
+        /// The case-sensitive name of a <see cref="ShaderParameter"/>, as it appears in the shader code.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The current value of a <see cref="ShaderParameter"/>.
+        /// </summary>
+        public Variant Value { get; set; }
+
+        /// <summary>
+        /// The minimum value of a <see cref="ShaderParameter"/>.
+        /// <para>
+        /// Defaults to <c>0.0</c>.
+        /// </para>
+        /// </summary>
+        public Variant MinValue { get; set; } = 0.0;
+
+        /// <summary>
+        /// The maximum value of a <see cref="ShaderParameter"/>.
+        /// </summary>
+        public Variant MaxValue { get; set; }
+    }
+}

--- a/Screens/root.tscn
+++ b/Screens/root.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=20 format=3 uid="uid://dtvpxppojlasm"]
+[gd_scene load_steps=21 format=3 uid="uid://dtvpxppojlasm"]
 
 [ext_resource type="Shader" path="res://Shaders/crt.gdshader" id="1_4876q"]
 [ext_resource type="PackedScene" uid="uid://u7cbeq44pw08" path="res://Screens/intro_screen.tscn" id="1_iu054"]
+[ext_resource type="Script" path="res://Shaders/Monitor.cs" id="2_lv3bt"]
 [ext_resource type="PackedScene" uid="uid://nddd2eqotbpa" path="res://Screens/console_screen.tscn" id="3_3efbf"]
 [ext_resource type="PackedScene" uid="uid://vu437t7g2cwv" path="res://Screens/welcome_screen.tscn" id="3_13snw"]
 [ext_resource type="AudioStream" uid="uid://dwryw0shwo6gj" path="res://Audio/Keyboard/keypress-001.ogg" id="5_yofx3"]
@@ -19,7 +20,7 @@
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_gl2w5"]
 shader = ExtResource("1_4876q")
-shader_parameter/overlay = false
+shader_parameter/overlay = true
 shader_parameter/scanlines_opacity = 0.2
 shader_parameter/scanlines_width = 0.059
 shader_parameter/grille_opacity = 0.088
@@ -71,6 +72,7 @@ grow_horizontal = 2
 grow_vertical = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
+script = ExtResource("2_lv3bt")
 
 [node name="IntroScreen" parent="Monitor" instance=ExtResource("1_iu054")]
 

--- a/Shaders/Monitor.cs
+++ b/Shaders/Monitor.cs
@@ -1,0 +1,38 @@
+using Godot;
+
+using Terminal.Constants;
+using Terminal.Extensions;
+using Terminal.Services;
+
+namespace Terminal.Shaders
+{
+    /// <summary>
+    /// A <see cref="ColorRect"/> <see cref="Node"/> managed in Godot that contains the overlay shader effects on each screen.
+    /// </summary>
+    public partial class Monitor : ColorRect
+    {
+        private ConfigService _configService;
+        private ShaderMaterial _shaderMaterial;
+
+        public override void _Ready()
+        {
+            _configService = GetNode<ConfigService>(ServicePathConstants.ConfigServicePath);
+            _shaderMaterial = (ShaderMaterial)Material;
+
+            // Load the initial config value for monitor shader effect.
+            AdjustShaderFromDisplayConfig(_configService.MonitorShaderIntensity);
+
+            // Whenever the user updates the config file, adjust it in real time.
+            _configService.OnDisplayConfigChange += AdjustShaderFromDisplayConfig;
+        }
+
+        private void AdjustShaderFromDisplayConfig(int displayConfigValue)
+        {
+            foreach(var shaderParameter in ShaderConstants.ShaderParameters)
+            {
+                shaderParameter.Value = displayConfigValue.ConvertRange(0, 100, shaderParameter.MinValue.AsDouble(), shaderParameter.MaxValue.AsDouble());
+                _shaderMaterial.SetShaderParameter(shaderParameter.Name, shaderParameter.Value);
+            }
+        }
+    }
+}

--- a/Shaders/Monitor.cs
+++ b/Shaders/Monitor.cs
@@ -23,7 +23,7 @@ namespace Terminal.Shaders
             AdjustShaderFromDisplayConfig(_configService.MonitorShaderIntensity);
 
             // Whenever the user updates the config file, adjust it in real time.
-            _configService.OnDisplayConfigChange += AdjustShaderFromDisplayConfig;
+            _configService.OnMonitorIntensityConfigChange += AdjustShaderFromDisplayConfig;
         }
 
         private void AdjustShaderFromDisplayConfig(int displayConfigValue)


### PR DESCRIPTION
# Description
This PR will add a `users/user/config/display.conf` file with a couple keys to impact both the CRT shader intensity and the font size.

The `monitor-effect-intensity` value can be set between `0` and `100`.

The `font-size` value can be set between `8` and `36`.

Both of these config values are part of the save file, are updated when a `.conf` file is saved, and reflected in real time.

## Updating monitor effect intensity
When editing the `users/user/config/display.conf` file, `monitor-effect-intensity:0` will disable the customizable shader effects entirely, and `monitor-effect-intensity:100` will set the customizable shader effects to their maximum values.

## Updating font size
When editing the `users/user/config/display.conf` file, `font-size:8` will adjust the font size to it's smallest allowable size, and `font-size:36` will adjust the font size to it's biggest allowable size.

## New models
This PR will also introduce the `ShaderParameter` model, to have a means to edit the shader's variables between a minimum and maximum value based on the `monitor-effect-intensity` value in `display.conf`.

## Other fixes
This PR will also fix an issue when loading a file into the file editor. Previously, there would be a new line inserted before the file's contents, which was because the input wasn't being stopped, but rather bubbled into the file editor when the user hit the enter key when running the `edit` command.