### PR TITLE
Fix autocomplete behavior after new Startup experience 

### DIFF
--- a/Containers/ScrollableContainer.cs
+++ b/Containers/ScrollableContainer.cs
@@ -132,7 +132,11 @@ namespace Terminal.Containers
 
             _ = _hardDriveSounds.PlayHardDriveSounds();
             await ShowHardwareBootMessages(hardwareBootOutput);
-            ShowWelcomeMessageAndInput();
+
+            _ = _hardDriveSounds.PlayHardDriveSounds();
+            ClearScreen();
+            CreateResponse($"DOT Personal Computer Terminal OS Version {ProjectSettings.GetSetting("application/config/version")}\n\n");
+            AddNewUserInput();
         }
 
         private async Task ShowHardwareBootMessages(List<string> hardwareBootMessages)
@@ -169,17 +173,9 @@ namespace Terminal.Containers
 
         private Label GetLastLabel() => GetChild<Label>(GetChildCount() - 1);
 
-        private void ShowWelcomeMessageAndInput()
-        {
-            _ = _hardDriveSounds.PlayHardDriveSounds();
-            ClearScreen();
-            CreateResponse($"DOT Personal Computer Terminal OS Version {ProjectSettings.GetSetting("application/config/version")}\n\n");
-            AddNewUserInput();
-        }
-
         private void ClearScreen()
         {
-            foreach(var child in GetChildren())
+            foreach(var child in GetChildren().Where(child => child is Label).Where(child => IsInstanceValid(child)))
             {
                 child.QueueFree();
             }
@@ -214,7 +210,7 @@ namespace Terminal.Containers
                 CaretBlink = true,
                 CaretMoveOnRightClick = false,
                 CaretMultiple = false,
-                Name = $"UserInput-{GetChildCount()}",
+                Name = $"UserInput",
                 GrowHorizontal = GrowDirection.End,
                 GrowVertical = GrowDirection.End,
                 ScrollFitContentHeight = true,
@@ -256,7 +252,7 @@ namespace Terminal.Containers
 
             var commandResponse = new Label()
             {
-                Name = $"Response-{GetChildCount()}",
+                Name = $"Response",
                 GrowHorizontal = GrowDirection.End,
                 GrowVertical = GrowDirection.End,
                 Theme = _defaultUserInputTheme,
@@ -283,7 +279,7 @@ namespace Terminal.Containers
         {
             var directoryResponse = new RichTextLabel()
             {
-                Name = $"Response-{GetChildCount()}",
+                Name = $"ListDirectoryResponse",
                 GrowHorizontal = GrowDirection.End,
                 GrowVertical = GrowDirection.End,
                 FitContent = true,

--- a/Services/AutoCompleteService.cs
+++ b/Services/AutoCompleteService.cs
@@ -170,6 +170,14 @@ namespace Terminal.Services
                     : filteredEntities.FirstOrDefault(p => p.Name.CompareTo(_autocompletedEntity.Name) > 0) ?? filteredEntities.FirstOrDefault();
             }
 
+            // if there are no matching entities, list the current directory contents fill up the next input with the current command.
+            if (matchingEntity == null)
+            {
+                OnInvalidAutocomplete?.Invoke(null);
+                OnAutocomplete?.Invoke(currentCommand);
+                return;
+            }
+
             // determine which path to show as a result
             var autoCompletedPath = (isAbsoluteSearch || isRootSearch || isCompleteAbsolutePath)
                 ? _directoryService.GetAbsoluteEntityPath(matchingEntity)


### PR DESCRIPTION
Turns out, using `.QueueFree()` on all children of the `ScrollableContainer` had adverse effects, like killing all references to the `UserInput`, so that broke auto complete.

It's fixed now 😄