### PR TITLE
Remove Godot ScriptGenerator warning from Unit Test project

### DIFF
--- a/tests/Terminal.UnitTests/Terminal.UnitTests.csproj
+++ b/tests/Terminal.UnitTests/Terminal.UnitTests.csproj
@@ -5,6 +5,15 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;8785</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <NoWarn>1701;1702;8785</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is in preparation for the new CI pipeline that will run these tests before a PR merges.

This warning was `CS8785`, so it was as easy as adding that warning to the exclusion list.