### PR TITLE
Add CI pipeline for running unit tests

### DIFF
--- a/.github/workflows/dotnet-8-unit-test-ci.yml
+++ b/.github/workflows/dotnet-8-unit-test-ci.yml
@@ -1,0 +1,27 @@
+# This workflow will build and test the Terminal.UnitTests .NET 8 project
+
+name: .NET
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Test
+      run: dotnet test --no-build --verbosity normal


### PR DESCRIPTION
This PR will add the yml necessary to create a .NET 8 CI pipeline whenever any pull request events or pushes happen to the `main` branch.

This required me to modify the existing branch ruleset I had in place, to require the `build` status check (which is defined in the yml as "jobs" only child).