### PR TITLE
Add "deletesave" command, spruce up README

### DIFF
--- a/.github/workflows/dotnet-8-unit-test-ci.yml
+++ b/.github/workflows/dotnet-8-unit-test-ci.yml
@@ -1,6 +1,6 @@
 # This workflow will build and test the Terminal.UnitTests .NET 8 project
 
-name: .NET
+name: .NET 8.0 unit tests
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
+![Unit Tests](https://github.com/evangipson/terminal-os/actions/workflows/dotnet-8-unit-test-ci.yml/badge.svg)
+
 # Terminal OS
-terminal_os is a terminal game written in the Godot engine using .NET 8 and C#.
+Terminal OS is a terminal game written in the Godot engine using .NET 8 and C#.
 
 https://github.com/user-attachments/assets/3dd76518-b6b1-4403-9dc3-a4ee95be8a44
 
@@ -11,7 +13,7 @@ https://github.com/user-attachments/assets/3dd76518-b6b1-4403-9dc3-a4ee95be8a44
 
 ## Features
 ### Informational Commands
-- View all the commands for terminal_os using the `commands` command
+- View all the commands using the `commands` command
 - Get help about any command using the `help` command
 - See the contents of any directory using the `list` command
 - List the hardware using the `listhardware` command
@@ -21,6 +23,8 @@ https://github.com/user-attachments/assets/3dd76518-b6b1-4403-9dc3-a4ee95be8a44
 
 ### State Commands
 - Save your game by using the `save` command
+- Delete your save game by using the `deletesave` command
+    - Warning: This command will remove save game; it is not recoverable
 - Exit the terminal using the `exit` command
 - Contextual autocomplete for commands by pressing tab
     - See previous autocomplete result using shift + tab
@@ -71,3 +75,18 @@ https://github.com/user-attachments/assets/3dd76518-b6b1-4403-9dc3-a4ee95be8a44
     - `/system/config/color.conf` to create/remove colors
     - `/users/user/config/display.conf` to modify the CRT monitor effect or font size
     - `/users/user/config/user.conf` to modify volume
+
+## Contributing
+### Coding Style
+- All `public` and `protected` methods and properties must be documented
+- Prefer using a `static` `class` which can be unit tested to accomplish small chunks of functionality instead of making everything a `Node`
+- Each `class` without a reference to Godot will have a unit test written for it in the `Terminal.UnitTests` project
+
+### Development Examples
+#### Adding a command
+1. Add the command to the `UserCommand` `enum` in `UserCommand.cs`
+1. Add the output for `help` for the new command by creating a new entry in the `AllDefaultCommands` property in `DirectoryConstants.cs`
+    - This will also create an executable for the command inside of `/system/programs/`
+1. Add the characters to trigger the command in the `EvaluateToken` method in `UserCommandService.cs`
+1. Add the help routing in the `EvaluateHelpCommand` method in `UserCommandService.cs`
+1. Add the functionality of the command in the `RouteCommand` method in `UserInput.cs`

--- a/src/Constants/DirectoryConstants.cs
+++ b/src/Constants/DirectoryConstants.cs
@@ -215,6 +215,11 @@ namespace Terminal.Constants
             {
                 ["COMMAND"] = "cls [clear] [clearscreen]",
                 ["REMARKS"] = "Clears the terminal screen.",
+            },
+            ["deletesave"] = new()
+            {
+                ["COMMAND"] = "deletesave",
+                ["REMARKS"] = "Deletes the saved state of the terminal.\nWARNING: There is no recovery of the saved state after running this command."
             }
         };
 

--- a/src/Enums/UserCommand.cs
+++ b/src/Enums/UserCommand.cs
@@ -41,6 +41,7 @@ namespace Terminal.Enums
         DeleteUserFromGroup,
         ViewGroup,
         ClearScreen,
+        DeleteSave,
         Unknown
     };
 }

--- a/src/Inputs/UserInput.cs
+++ b/src/Inputs/UserInput.cs
@@ -273,6 +273,7 @@ namespace Terminal.Inputs
                 UserCommand.DeleteUserFromGroup => () => CreateSimpleTerminalResponse(_userService.DeleteUserFromGroup(parsedTokens.Skip(1))),
                 UserCommand.ViewGroup => () => CreateSimpleTerminalResponse(_userService.ViewUserGroup(parsedTokens.Take(2).Last())),
                 UserCommand.ClearScreen => () => EmitSignal(SignalName.ClearScreen),
+                UserCommand.DeleteSave => () => CreateSimpleTerminalResponse(_persistService.DeleteSaveGame()),
                 _ => () => CreateSimpleTerminalResponse($"\"{parsedTokens.First()}\" is an unknown command. Use \"commands\" to get a list of available commands.")
             };
         }

--- a/src/Services/PersistService.cs
+++ b/src/Services/PersistService.cs
@@ -90,6 +90,36 @@ namespace Terminal.Services
             SaveDataToFile(_path, _fileName, saveDataJson);
         }
 
+        /// <summary>
+        /// Deletes the save game JSON file, if it exists.
+        /// <para>
+        /// Logs an error if it does not exist.
+        /// </para>
+        /// </summary>
+        public string DeleteSaveGame()
+        {
+            if (!Directory.Exists(_path))
+            {
+                return "Unable to remove saved state, one did not exist.";
+            }
+
+            var saveFileLocation = Path.Join(_path, _fileName);
+            if(!File.Exists(saveFileLocation))
+            {
+                return "Unable to remove saved state, one did not exist.";
+            }
+
+            try
+            {
+                File.Delete(saveFileLocation);
+                return "Saved state deleted.";
+            }
+            catch (Exception)
+            {
+                return "Could not delete saved state.";
+            }
+        }
+
         private void LoadGame()
         {
             var saveDataJson = LoadDataFromFile(_path, _fileName);

--- a/src/Services/UserCommandService.cs
+++ b/src/Services/UserCommandService.cs
@@ -105,6 +105,7 @@ namespace Terminal.Services
             "dug" or "removeuser" or "deleteuserfromgroup" => UserCommand.DeleteUserFromGroup,
             "vg" or "viewgroup" => UserCommand.ViewGroup,
             "cls" or "clear" or "clearscreen" => UserCommand.ClearScreen,
+            "deletesave" => UserCommand.DeleteSave,
             _ => UserCommand.Unknown
         };
 
@@ -199,6 +200,7 @@ namespace Terminal.Services
                 UserCommand.DeleteUserFromGroup => GetOutputFromTokens(AllCommands["deleteuserfromgroup"]),
                 UserCommand.ViewGroup => GetOutputFromTokens(AllCommands["viewgroup"]),
                 UserCommand.ClearScreen => GetOutputFromTokens(AllCommands["clearscreen"]),
+                UserCommand.DeleteSave => GetOutputFromTokens(AllCommands["deletesave"]),
                 _ => string.Empty
             };
         }


### PR DESCRIPTION
This PR will add the `deletesave` command, along with `help` text. There was an update to the `PersistService` to accomplish the actual functionality.

There is also updates the README which outline `Contribution` guidelines, like `Coding Style` and `Development Examples` (where the flow of adding a command was captured). There was also an update to the README to add the badge for the status of the .NET 8 Unit Tests status.